### PR TITLE
Fix the bug: args of warmup_steps has been changed to warmup_ratio in…

### DIFF
--- a/sources/llamafactory/quick_start.rst
+++ b/sources/llamafactory/quick_start.rst
@@ -72,7 +72,7 @@ yaml 配置文件
     learning_rate: 0.0001
     num_train_epochs: 3.0
     lr_scheduler_type: cosine
-    warmup_steps: 0.1
+    warmup_ratio: 0.1
     fp16: true
 
     ### eval


### PR DESCRIPTION
Fix the bug: args of warmup_steps has been changed to warmup_ratio in fine tune yaml config file.
origin error information as following:
root@f40d90b7313d:/app# torchrun --nproc_per_node 1 \
    --nnodes 1 \
    --node_rank 0 \
    --master_addr 127.0.0.1 \
    --master_port 7007 \
    src/train.py qwen1_5_lora_sft_ds.yaml
[2025-02-24 14:13:53,041] [INFO] [real_accelerator.py:222:get_accelerator] Setting ds_accelerator to npu (auto detect)
/usr/local/python3.10/lib/python3.10/site-packages/transformers/training_args.py:1594: FutureWarning: `evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead
  warnings.warn(
[2025-02-24 14:13:54,047] [INFO] [comm.py:652:init_distributed] cdb=None
[2025-02-24 14:13:54,048] [INFO] [comm.py:683:init_distributed] Initializing TorchBackend in DeepSpeed with backend hccl
Traceback (most recent call last):
  File "/app/src/train.py", line 28, in <module>
    main()
  File "/app/src/train.py", line 19, in main
    run_exp()
  File "/app/src/llamafactory/train/tuner.py", line 93, in run_exp
    _training_function(config={"args": args, "callbacks": callbacks})
  File "/app/src/llamafactory/train/tuner.py", line 53, in _training_function
    model_args, data_args, training_args, finetuning_args, generating_args = get_train_args(args)
  File "/app/src/llamafactory/hparams/parser.py", line 189, in get_train_args
    model_args, data_args, training_args, finetuning_args, generating_args = _parse_train_args(args)
  File "/app/src/llamafactory/hparams/parser.py", line 167, in _parse_train_args
    return _parse_args(parser, args, allow_extra_keys=allow_extra_keys)
  File "/app/src/llamafactory/hparams/parser.py", line 77, in _parse_args
    return parser.parse_dict(args, allow_extra_keys=allow_extra_keys)
  File "/usr/local/python3.10/lib/python3.10/site-packages/transformers/hf_argparser.py", line 392, in parse_dict
    obj = dtype(**inputs)
  File "<string>", line 144, in __init__
  File "/app/src/llamafactory/hparams/training_args.py", line 51, in __post_init__
    Seq2SeqTrainingArguments.__post_init__(self)
  File "/usr/local/python3.10/lib/python3.10/site-packages/transformers/training_args.py", line 1894, in __post_init__
    raise ValueError("warmup_steps must be of type int and must be 0 or a positive integer.")
ValueError: warmup_steps must be of type int and must be 0 or a positive integer.
[2025-02-24 14:13:59,269] torch.distributed.elastic.multiprocessing.api: [ERROR] failed (exitcode: 1) local_rank: 0 (pid: 2730) of binary: /usr/local/python3.10/bin/python3.10
Traceback (most recent call last):
  File "/usr/local/python3.10/bin/torchrun", line 8, in <module>
    sys.exit(main())
  File "/usr/local/python3.10/lib/python3.10/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/python3.10/lib/python3.10/site-packages/torch/distributed/run.py", line 806, in main
    run(args)
  File "/usr/local/python3.10/lib/python3.10/site-packages/torch/distributed/run.py", line 797, in run
    elastic_launch(
  File "/usr/local/python3.10/lib/python3.10/site-packages/torch/distributed/launcher/api.py", line 134, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/usr/local/python3.10/lib/python3.10/site-packages/torch/distributed/launcher/api.py", line 264, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError:s