### PR TITLE
Fix llamafactory quick start error

### DIFF
--- a/sources/llamafactory/install.rst
+++ b/sources/llamafactory/install.rst
@@ -102,10 +102,9 @@ LLAMA-Factory 下载安装
                   <p>启动 docker 容器：</p>
                   <div class="highlight">
                     <pre>docker run -dit \
-    -v ./hf_cache:/root/.cache/huggingface \
-    -v ./ms_cache:/root/.cache/modelscope \
-    -v ./data:/app/data \
-    -v ./output:/app/output \
+    -v $PWD/hf_cache:/root/.cache/huggingface \
+    -v $PWD/ms_cache:/root/.cache/modelscope \
+    -v $PWD/output:/app/output \
     -v /usr/local/dcmi:/usr/local/dcmi \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \

--- a/sources/llamafactory/quick_start.rst
+++ b/sources/llamafactory/quick_start.rst
@@ -78,7 +78,7 @@ yaml 配置文件
     ### eval
     val_size: 0.1
     per_device_eval_batch_size: 1
-    evaluation_strategy: steps
+    eval_strategy: steps
     eval_steps: 500
         </pre>
       </div>


### PR DESCRIPTION
1. llamafactory中配置文件的`evaluation_strategy`已经变更为`eval_strategy`，文档未及时更新，导致出现以下错误：
```
[2025-07-03 10:57:22,319] [INFO] [real_accelerator.py:254:get_accelerator] Setting ds_accelerator to npu (auto detect)
/usr/local/python3.11.12/lib/python3.11/site-packages/jieba/_compat.py:18: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
[2025-07-03 10:57:24,731] [INFO] [comm.py:669:init_distributed] cdb=None
[2025-07-03 10:57:24,731] [INFO] [comm.py:700:init_distributed] Initializing TorchBackend in DeepSpeed with backend hccl
[rank0]: Traceback (most recent call last):
[rank0]:   File "/app/src/train.py", line 28, in <module>
[rank0]:     main()
[rank0]:   File "/app/src/train.py", line 19, in main
[rank0]:     run_exp()
[rank0]:   File "/app/src/llamafactory/train/tuner.py", line 110, in run_exp
[rank0]:     _training_function(config={"args": args, "callbacks": callbacks})
[rank0]:   File "/app/src/llamafactory/train/tuner.py", line 55, in _training_function
[rank0]:     model_args, data_args, training_args, finetuning_args, generating_args = get_train_args(args)
[rank0]:                                                                              ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/app/src/llamafactory/hparams/parser.py", line 209, in get_train_args
[rank0]:     model_args, data_args, training_args, finetuning_args, generating_args = _parse_train_args(args)
[rank0]:                                                                              ^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/app/src/llamafactory/hparams/parser.py", line 187, in _parse_train_args
[rank0]:     return _parse_args(parser, args, allow_extra_keys=allow_extra_keys)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/app/src/llamafactory/hparams/parser.py", line 78, in _parse_args
[rank0]:     return parser.parse_dict(args, allow_extra_keys=allow_extra_keys)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/python3.11.12/lib/python3.11/site-packages/transformers/hf_argparser.py", line 396, in parse_dict
[rank0]:     raise ValueError(f"Some keys are not used by the HfArgumentParser: {sorted(unused_keys)}")
[rank0]: ValueError: Some keys are not used by the HfArgumentParser: ['evaluation_strategy']
[ERROR] 2025-07-03-10:57:26 (PID:3028, Device:0, RankID:-1) ERR99999 UNKNOWN applicaiton exception
```

2. 删除容器运行命令中挂载本地`data`目录的选项，这个选项会在本地`data`是空是导致进入容器后运行出错。实际进入容器后直接使用/app/data的数据即可正常运行