### PR TITLE
fix(workflow): use make html instead of direct sphinx-build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build
         run: |
-          sphinx-build -b html ./ _build/html
+          make html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fix missing subproject documentation (e.g., verl) in online deployment.

Problem:
- Direct sphinx-build call skipped the documentation copy step in Makefile
- _repos/verl/docs/ascend_tutorial was not copied to sources/verl

Solution:
- Replace sphinx-build command with make html
- Ensure complete build process including submodule initialization and doc copying