### PR TITLE
fix lm_eval install error

### DIFF
--- a/sources/lm_evaluation/install.rst
+++ b/sources/lm_evaluation/install.rst
@@ -15,7 +15,7 @@
 lm-evaluation-harness安装
 ----------------------------------
 
-注意：lm-evaluation-harness从0.4.3开始原生支持昇腾。
+注意：lm-evaluation-harness从0.4.3开始原生支持昇腾。当使用0.4.10以下版本时，transformers库需要小于5.0.0。
 
 - Option 1: Use the latest stable release
 


### PR DESCRIPTION
由于lm_eval没有限制transformers版本，导致lm_eval版本在小于0.4.10时使用transformers版本为5.0.0会报错。