### PR TITLE
update github link button

### DIFF
--- a/_static/statistics.js
+++ b/_static/statistics.js
@@ -5,3 +5,17 @@ var _hmt = _hmt || [];
   var s = document.getElementsByTagName("script")[0]; 
   s.parentNode.insertBefore(hm, s);
 })();
+
+document.addEventListener('DOMContentLoaded', function () {
+  var aside = document.querySelector('.wy-breadcrumbs-aside');
+  if (!aside) return;
+  var anchors = aside.querySelectorAll('a');
+  if (anchors.length) {
+    anchors.forEach(function (a) {
+      a.setAttribute('href', 'https://github.com/Ascend/docs');
+      a.setAttribute('target', '_blank');
+      a.textContent = '访问 GitHub 仓库';
+    });
+  }
+});
+


### PR DESCRIPTION
Update the GitHub link button so that the button on every page points to the GitHub homepage.

<img width="2439" height="915" alt="image" src="https://github.com/user-attachments/assets/2bd96b79-8ea7-4c13-b8d5-f55c3590f317" />
