### PR TITLE
[feat] add --depth=1 for Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,12 +5,15 @@
 [submodule "_repos/LLaMA-Factory"]
 	path = _repos/LLaMA-Factory
 	url = https://github.com/the-seeds/LLaMA-Factory-Doc.git
+	branch = main
 [submodule "_repos/VeOmni"]
 	path = _repos/VeOmni
 	url = https://github.com/ByteDance-Seed/VeOmni.git
+	branch = main
 [submodule "_repos/ms-swift"]
 	path = _repos/ms-swift
 	url = https://github.com/modelscope/ms-swift.git
+	branch = main
 [submodule "_repos/vllm-ascend"]
 	path = _repos/vllm-ascend
 	url = https://github.com/vllm-project/vllm-ascend.git
@@ -22,3 +25,4 @@
 [submodule "_repos/deepspeed"]
 	path = _repos/deepspeed
 	url = https://github.com/deepspeedai/DeepSpeed.git
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ init-submodules:
 	@git submodule sync --recursive
 	@n=0; \
 	while [ $$n -lt 3 ]; do \
-		git submodule update --init --remote && exit 0; \
+		git submodule update --init --depth=1 --remote && exit 0; \
 		n=$$((n+1)); \
 		echo "git submodule update failed (attempt $$n/3), retrying in 8s..."; \
 		sleep 8; \


### PR DESCRIPTION
## Motivation

Add `--depth=1` to `Makefile` to reduce git clone time. Since `Ascend/docs` always uses the latest commit from the submodule, this flag won't cause build errors.