### PR TITLE
ci: 增加自建 runner 可用性探测

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - linux-aarch64-a2-2
+    - linux-aarch64-a3-2

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,12 @@
 self-hosted-runner:
   labels:
+    - linux-aarch64-a2-1
     - linux-aarch64-a2-2
+    - linux-aarch64-a2-4
+    - linux-aarch64-a2-8
+    - linux-aarch64-a2-16
+    - linux-aarch64-a3-1
     - linux-aarch64-a3-2
+    - linux-aarch64-a3-4
+    - linux-aarch64-a3-8
+    - linux-aarch64-a3-16

--- a/.github/workflows/probe-self-hosted-runners.yml
+++ b/.github/workflows/probe-self-hosted-runners.yml
@@ -1,0 +1,100 @@
+# Manual probe: can this repo schedule a job on the two NPU runner
+# labels, pull an AscendHub CANN image, and see the cards?
+#
+# How to read a run:
+#   - Job stays queued: this repo has no matching scale set, or no idle capacity.
+#   - Job starts then fails on image pull / container create: runner is up; the
+#     container path is broken (wrong tag, hook, or device plugin).
+#   - Job is green and npu-smi lists devices: that label is usable.
+#
+# schedule stays commented. Do not enable until someone decides this should
+# be a standing health check.
+name: Probe self-hosted runners
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '17 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: linux-aarch64-a2-2
+            image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+          - runner: linux-aarch64-a3-2
+            image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-a3-ubuntu22.04-py3.12
+    defaults:
+      run:
+        shell: bash
+    env:
+      ASCEND_RT_VISIBLE_DEVICES: "0,1"
+    # container.image is required on these ARC runners; without it the job
+    # may start but NPU is not allocated. Do not use ${{ env.* }} here —
+    # that context is not available for image.
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - name: Probe host and NPU
+        env:
+          RUNNER_LABEL: ${{ matrix.runner }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/sbin:/usr/local/bin:${PATH}"
+          if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then
+            # shellcheck disable=SC1091
+            source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          fi
+
+          echo "=== runner ==="
+          echo "RUNNER_NAME=${RUNNER_NAME:-}"
+          echo "RUNNER_OS=${RUNNER_OS:-}"
+          echo "RUNNER_ARCH=${RUNNER_ARCH:-}"
+          echo "RUNNER_LABEL=${RUNNER_LABEL}"
+          echo "IMAGE=${IMAGE}"
+          hostname || true
+          uname -a
+
+          echo "=== devices ==="
+          ls -l /dev/davinci* /dev/davinci_manager /dev/devmm_svm /dev/hisi_hdc 2>&1 || true
+
+          echo "=== npu-smi ==="
+          npu-smi info
+
+          npu_nodes="$(find /dev -maxdepth 1 -type c -name 'davinci[0-9]*' | wc -l | tr -d ' ')"
+          echo "davinci_nodes=${npu_nodes}"
+          if [ "${npu_nodes}" -lt 2 ]; then
+            echo "expected at least 2 NPU device nodes on a *-2 runner, got ${npu_nodes}" >&2
+            exit 1
+          fi
+
+  summarize:
+    name: summarize
+    needs: probe
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report probe result
+        env:
+          PROBE_RESULT: ${{ needs.probe.result }}
+        run: |
+          set -euo pipefail
+          echo "probe matrix result: ${PROBE_RESULT}"
+          if [ "${PROBE_RESULT}" != "success" ]; then
+            echo "one or both runner labels failed or did not finish" >&2
+            exit 1
+          fi
+          echo "both linux-aarch64-a2-2 and linux-aarch64-a3-2 picked up a job and saw NPU"

--- a/.github/workflows/probe-self-hosted-runners.yml
+++ b/.github/workflows/probe-self-hosted-runners.yml
@@ -1,11 +1,16 @@
-# Manual probe: can this repo schedule a job on the two NPU runner
-# labels, pull an AscendHub CANN image, and see the cards?
+# Manual probe: can this repo schedule a job on each NPU runner label,
+# pull the matching AscendHub CANN image, and see that many cards?
+#
+# Label shape: linux-aarch64-<chip>-<npu>
+#   chip: a2 (910B) or a3 (910C)
+#   npu:  available card count for that scale set (1 / 2 / 4 / 8 / 16)
 #
 # How to read a run:
 #   - Job stays queued: this repo has no matching scale set, or no idle capacity.
 #   - Job starts then fails on image pull / container create: runner is up; the
 #     container path is broken (wrong tag, hook, or device plugin).
-#   - Job is green and npu-smi lists devices: that label is usable.
+#   - Job is green and npu-smi lists the expected number of devices: that
+#     label is usable.
 #
 # schedule stays commented. Do not enable until someone decides this should
 # be a standing health check.
@@ -25,32 +30,28 @@ permissions:
 
 jobs:
   probe:
-    name: ${{ matrix.runner }}
-    runs-on: ${{ matrix.runner }}
+    name: linux-aarch64-${{ matrix.chip }}-${{ matrix.npu }}
+    runs-on: linux-aarch64-${{ matrix.chip }}-${{ matrix.npu }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: linux-aarch64-a2-2
-            image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
-          - runner: linux-aarch64-a3-2
-            image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-a3-ubuntu22.04-py3.12
+        chip: [a2, a3]
+        npu: [1, 2, 4, 8, 16]
     defaults:
       run:
         shell: bash
-    env:
-      ASCEND_RT_VISIBLE_DEVICES: "0,1"
     # container.image is required on these ARC runners; without it the job
     # may start but NPU is not allocated. Do not use ${{ env.* }} here —
     # that context is not available for image.
     container:
-      image: ${{ matrix.image }}
+      image: ${{ matrix.chip == 'a2' && 'swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12' || 'swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-a3-ubuntu22.04-py3.12' }}
     steps:
       - name: Probe host and NPU
         env:
-          RUNNER_LABEL: ${{ matrix.runner }}
-          IMAGE: ${{ matrix.image }}
+          RUNNER_LABEL: linux-aarch64-${{ matrix.chip }}-${{ matrix.npu }}
+          IMAGE: ${{ matrix.chip == 'a2' && 'swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12' || 'swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-a3-ubuntu22.04-py3.12' }}
+          NPU_COUNT: ${{ matrix.npu }}
         run: |
           set -euo pipefail
           export PATH="/usr/local/sbin:/usr/local/bin:${PATH}"
@@ -59,12 +60,24 @@ jobs:
             source /usr/local/Ascend/ascend-toolkit/set_env.sh
           fi
 
+          ids=()
+          i=0
+          while [ "${i}" -lt "${NPU_COUNT}" ]; do
+            ids+=("${i}")
+            i=$((i + 1))
+          done
+          IFS=,
+          export ASCEND_RT_VISIBLE_DEVICES="${ids[*]}"
+          unset IFS
+
           echo "=== runner ==="
           echo "RUNNER_NAME=${RUNNER_NAME:-}"
           echo "RUNNER_OS=${RUNNER_OS:-}"
           echo "RUNNER_ARCH=${RUNNER_ARCH:-}"
           echo "RUNNER_LABEL=${RUNNER_LABEL}"
           echo "IMAGE=${IMAGE}"
+          echo "NPU_COUNT=${NPU_COUNT}"
+          echo "ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES}"
           hostname || true
           uname -a
 
@@ -76,8 +89,8 @@ jobs:
 
           npu_nodes="$(find /dev -maxdepth 1 -type c -name 'davinci[0-9]*' | wc -l | tr -d ' ')"
           echo "davinci_nodes=${npu_nodes}"
-          if [ "${npu_nodes}" -lt 2 ]; then
-            echo "expected at least 2 NPU device nodes on a *-2 runner, got ${npu_nodes}" >&2
+          if [ "${npu_nodes}" -lt "${NPU_COUNT}" ]; then
+            echo "expected at least ${NPU_COUNT} NPU device nodes on ${RUNNER_LABEL}, got ${npu_nodes}" >&2
             exit 1
           fi
 
@@ -94,7 +107,7 @@ jobs:
           set -euo pipefail
           echo "probe matrix result: ${PROBE_RESULT}"
           if [ "${PROBE_RESULT}" != "success" ]; then
-            echo "one or both runner labels failed or did not finish" >&2
+            echo "one or more runner labels failed or did not finish" >&2
             exit 1
           fi
-          echo "both linux-aarch64-a2-2 and linux-aarch64-a3-2 picked up a job and saw NPU"
+          echo "all linux-aarch64-a2/a3 labels (1/2/4/8/16 cards) picked up a job and saw NPU"


### PR DESCRIPTION
## 摘要

- 新增一条只支持手动触发（`workflow_dispatch`）的探测流水线，覆盖 A2 / A3 各档卡数的 runner 标签。
- `a2` / `a3` 是机器型号（A2 = 910B，A3 = 910C）；标签尾部数字是该档 scale set 可用的卡数。
- 每个 job 拉取对应芯片系列的 AscendHub CANN 镜像，运行 `npu-smi info`，并检查容器里至少能看到与标签尾部数字相同数量的 NPU 设备节点。
- 在 `.github/actionlint.yaml` 里登记这些 runner 标签，避免 `actionlint` 把它们当成未知标签。

覆盖的标签：

| 型号 | 1 卡 | 2 卡 | 4 卡 | 8 卡 | 16 卡 |
| --- | --- | --- | --- | --- | --- |
| A2 | `linux-aarch64-a2-1` | `linux-aarch64-a2-2` | `linux-aarch64-a2-4` | `linux-aarch64-a2-8` | `linux-aarch64-a2-16` |
| A3 | `linux-aarch64-a3-1` | `linux-aarch64-a3-2` | `linux-aarch64-a3-4` | `linux-aarch64-a3-8` | `linux-aarch64-a3-16` |

这是探测流水线，不是文档构建。某个 job 一直停在排队（Queued），说明这个仓还没有对应的 scale set，或当时没有空闲容量。job 变绿且日志里有 `npu-smi` 输出、设备节点数达到标签要求，说明该标签能在本仓接活。

`fail-fast: false`：一档失败不会取消其他档，两边可以分别看。定时任务（`schedule`）保持注释，避免合入后按点占 NPU。

## 测试计划

- [ ] 合入 `main`（或确认 workflow 文件已在默认分支上），然后在 Actions 页运行 **Probe self-hosted runners**，或使用 `gh workflow run`。
- [ ] 确认上表 10 个标签各自被接走，且 `npu-smi` 列出的卡数不少于标签尾部数字。
- [ ] 若某个 job 一直排队，把该标签视为对 `Ascend/docs` 尚不可用。