### PR TITLE
ci: preview rendered docs on every pull request

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,15 +8,15 @@ on:
     branches:
       - main
   workflow_dispatch:
-  
+
 permissions:
-  contents: write      
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,9 +33,52 @@ jobs:
         run: |
           make html
 
+      # PR builds run untrusted code with a read-only token, so they cannot publish.
+      # The artifact name carries the PR number: workflow_run events do not populate
+      # `pull_requests` for fork PRs, and this is how pr-preview-deploy.yml recovers it.
+      - name: Upload site
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event_name == 'pull_request' && format('docs-preview-{0}', github.event.number) || 'docs-site' }}
+          path: _build/html
+          include-hidden-files: true
+          retention-days: 7
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: _build/html
+
+      # force_orphan below rewrites gh-pages from scratch, which would drop the
+      # previews of every open PR. Carry them over into the new tree.
+      - name: Preserve open PR previews
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          if git clone --depth=1 --branch gh-pages --single-branch \
+              "https://github.com/${REPO}.git" /tmp/gh-pages 2>/dev/null; then
+            if [ -d /tmp/gh-pages/pr-preview ]; then
+              cp -r /tmp/gh-pages/pr-preview _build/html/
+              echo "Preserved previews:"
+              find /tmp/gh-pages/pr-preview -mindepth 1 -maxdepth 1 -type d
+            else
+              echo "No PR previews to preserve."
+            fi
+          else
+            echo "gh-pages branch not found; nothing to preserve."
+          fi
+
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,50 @@
+name: PR Preview Cleanup
+
+# pull_request_target carries a write token, which is only safe because this
+# workflow never checks out or executes pull request code: it checks out
+# gh-pages and deletes one directory.
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  remove-preview:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory
+        id: remove
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          dir="pr-preview/pr-${PR_NUMBER}"
+          if [ ! -d "$dir" ]; then
+            echo "No preview at ${dir}."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm -rq "$dir"
+          git commit -m "Remove preview for PR #${PR_NUMBER}"
+          git push
+          echo "removed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Update preview comment
+        if: steps.remove.outputs.removed == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          number: ${{ github.event.number }}
+          message: |
+            📖 文档预览已随本 PR 关闭而清理。

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,104 @@
+name: PR Preview Deploy
+
+# Runs in a trusted context: the workflow definition always comes from the
+# default branch and no pull request code is checked out here. Its only inputs
+# are the artifact produced by the (untrusted) PR build and the GitHub API.
+on:
+  workflow_run:
+    workflows: ["Github Pages"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  pages: read
+
+jobs:
+  deploy-preview:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write
+    steps:
+      # A fork PR builds its own copy of the build workflow, so the artifact name
+      # is attacker-controlled. Accept digits only, and require the PR it names to
+      # actually be the one that produced this run.
+      - name: Resolve and verify PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner: context.repo.owner, repo: context.repo.repo, run_id: runId },
+            );
+            const match = artifacts
+              .map((a) => /^docs-preview-(\d+)$/.exec(a.name))
+              .find(Boolean);
+            if (!match) {
+              core.warning('No docs-preview-<number> artifact in run ' + runId);
+              return;
+            }
+            const number = Number(match[1]);
+            const builtSha = context.payload.workflow_run.head_sha;
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+            });
+            // Also skips stale builds: a newer push to the same PR moved head.sha
+            // on, and deploying this one would resurrect an older preview.
+            if (pr.data.head.sha !== builtSha) {
+              core.warning(
+                `PR #${number} is at ${pr.data.head.sha}, not the built ${builtSha}.`,
+              );
+              return;
+            }
+            // Read the site URL instead of hardcoding it, so forks used for
+            // rehearsing this workflow link to their own Pages site.
+            let base = `https://${context.repo.owner}.github.io/${context.repo.repo}`;
+            try {
+              const pages = await github.rest.repos.getPages(context.repo);
+              base = pages.data.html_url.replace(/\/+$/, '');
+            } catch (error) {
+              core.warning(`Could not read Pages config (${error.message}); using ${base}`);
+            }
+            core.setOutput('deploy', 'true');
+            core.setOutput('number', String(number));
+            core.setOutput('sha', builtSha);
+            core.setOutput('base', base);
+
+      - if: steps.pr.outputs.deploy == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-preview-${{ steps.pr.outputs.number }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: site
+
+      - name: Deploy preview
+        if: steps.pr.outputs.deploy == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          destination_dir: pr-preview/pr-${{ steps.pr.outputs.number }}
+          commit_message: "Deploy preview for PR #${{ steps.pr.outputs.number }}"
+
+      - name: Comment preview URL
+        if: steps.pr.outputs.deploy == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            📖 **文档预览**：${{ steps.pr.outputs.base }}/pr-preview/pr-${{ steps.pr.outputs.number }}/
+
+            构建自 `${{ steps.pr.outputs.sha }}`，页面上线约需 1 分钟。
+            每次推送后自动更新，PR 关闭时自动清理。

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Here is how you can create a new docs:
 1. Create a rst file. You can put it anywhere, but it must be better to classify it.
 2. Add the rst into the index.rst
 
+## PR preview
+
+Every pull request gets a rendered preview of the whole site. Once the `Github Pages`
+build finishes (about 10 minutes), a bot comments the link on the PR:
+
+```
+https://ascend.github.io/docs/pr-preview/pr-<PR number>/
+```
+
+It is rebuilt on every push and deleted when the PR is closed. If the build fails,
+no preview is published — check the failure in the Actions tab.
+
 # Building locally
 
 When the development is ready, you can check and test it locally by following the directives below:


### PR DESCRIPTION
## TL;DR

每个 PR 会在 `https://ascend.github.io/docs/pr-preview/pr-<number>/` 得到一份可点击的 Sphinx 渲染预览供 reviewer 审查；bot 会在 PR 里发一条 sticky comment 贴 URL，后续 push 更新同一条 comment；PR 关闭后自动删除对应预览目录。

## Why split into two workflows

由于做原生支持的同事对该仓只有 Read 权限，几乎所有 PR 都来自 fork。fork 上的 `pull_request` workflow 只能拿到 read-only token，不能写 `gh-pages`，也不能读取 secrets。

因此拆成两个 workflows：

1. **`gh-pages.yml`（`build`）** — 在 PR / `main` 上构建 Sphinx，上传 `_build/html` 为 artifact；只有合入到 main 分支后才 deploy 到正式站点。
2. **`pr-preview-deploy.yml`（`workflow_run`）** — 在默认分支定义的受信任 workflow 里发布预览；只消费 `gh-pages.yaml` `build` 产出的 artifact。这样 fork 上可以跑不可信的 Sphinx/`conf.py`，预览发布仍在仓库可控地完成。

## How to review

建议按此顺序读：

1. **`pr-preview-deploy.yml`** — trust boundary、artifact 名解析、SHA 校验
2. **`gh-pages.yml`** — artifact 命名、`main` deploy 前保留 `gh-pages` 上已有 `pr-preview/`
3. **`pr-preview-cleanup.yml`** — PR 关闭时的清理路径
4. **`README.md`** — 贡献者说明

## Changes

| File | What changed |
|------|----------------|
| `.github/workflows/gh-pages.yml` | 拆成 `build` + `deploy`；PR/`main` 都上传 artifact（PR: `docs-preview-<N>`，main: `docs-site`）；仅 `main` deploy；orphan 重写 `gh-pages` 前把现有 `pr-preview/` 拷回新树；`peaceiris/actions-gh-pages` v3 → v4 |
| `.github/workflows/pr-preview-deploy.yml` | **新增** — `workflow_run` 监听 "Github Pages" 成功；从 artifact 名恢复 PR number；校验 `head.sha`；发布到 `pr-preview/pr-<N>`；sticky comment |
| `.github/workflows/pr-preview-cleanup.yml` | **新增** — `pull_request_target` + `closed`；checkout `gh-pages`（非 PR 代码）；`git rm` 预览目录；更新 comment |
| `README.md` | 新增 "PR preview" 小节：URL 规则、构建失败则无预览 |

所有写 `gh-pages` 的 job 共用 concurrency group `gh-pages-write`，避免 main deploy / preview deploy / cleanup 互相覆盖。

过期 preview deploy（已有更新 push）走 `core.warning`，job 仍为 green，不算失败。

## Risk

**Trust model（必须理解）：**

- Fork PR 的 **build** 跑不可信代码，但只能用 read-only token，产物仅是 artifact。
- **Preview publish** 用 write token，但 workflow 定义来自默认分支，**从不 checkout PR 源码**。
- Fork PR 上 artifact 名由 PR 作者侧的 `gh-pages.yml` 控制。因此 deploy 侧只接受 `^docs-preview-(\d+)$`，且必须校验该 PR 的 `head.sha` 与本次 build SHA 一致；否则 crafted 名称可能写到 `pr-preview/` 之外、覆盖正式站点。
- 任何能开 PR 的人都能在 `ascend.github.io` 下发布 HTML/JS。站点无登录/cookie，主要风险是钓鱼/垃圾内容挂在官方域名上，不是 session 劫持。首次贡献者仍需 maintainer 批准 Actions 后才跑 workflow。
- **未**加 collaborator-only 或 `preview` label gate：作者是 `CONTRIBUTOR` 而非 `COLLABORATOR`，该 gate 会把作者自己也挡在外面。
- **未**用 `pull_request_target` 去 build PR 的 Sphinx/`conf.py` — 那是 pwn-request 路径，本 PR 刻意避开。

可选后续（**不在本 PR 范围**）：label gate、Pages 子域隔离等。

## Test plan

### Fork rehearsal（已完成）

在作者 fork 上端到端验证：[licy666/docs#1](https://github.com/licy666/docs/pull/1)（已关闭）

- [x] Bot comment 给出 `https://licy666.github.io/docs/pr-preview/pr-1/`
- [x] 预览 HTML 含 live fork 首页没有的唯一 marker
- [x] `_static/custom.css` 与 theme CSS 在子路径下 HTTP 200（相对链接正常）
- [x] 第二次 push 更新同一条 sticky comment（新 SHA）且页面内容变化
- [x] 关闭 PR 后 `pr-preview/` 从 `gh-pages` 删除，comment 提示已清理，预览 URL 404
- [x] Live 首页未被影响

耗时参考：Sphinx build ~8.5 min；preview deploy ~8–14 s。