### PR TITLE
ci: 提升 PR 文档预览功能的易用性

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -81,6 +81,112 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: site
 
+      # Deep-link to sources/<project>/ when the PR touches exactly one project.
+      # Paths are taken from the GitHub API (not PR code) and only used if the
+      # matching index.html is already in the downloaded artifact.
+      - name: Resolve preview landing page
+        if: steps.pr.outputs.deploy == 'true'
+        id: landing
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PAGES_BASE: ${{ steps.pr.outputs.base }}
+          BUILT_SHA: ${{ steps.pr.outputs.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const number = process.env.PR_NUMBER;
+            const base = process.env.PAGES_BASE.replace(/\/+$/, '');
+            const sha = process.env.BUILT_SHA;
+            const siteRoot = `${base}/pr-preview/pr-${number}/`;
+
+            const footer = [
+              `构建自 \`${sha}\`。`,
+              '每次推送后自动更新，PR 关闭时自动清理。',
+            ];
+
+            const homepageMessage = [
+              `📖 **文档预览**：${siteRoot}`,
+              '',
+              ...footer,
+            ].join('\n');
+
+            const write = (primary, extraLines) => {
+              core.info(`Preview landing: ${primary}`);
+              const lines = [`📖 **文档预览**：${primary}`, ''];
+              if (extraLines.length) {
+                lines.push(...extraLines, '');
+              }
+              lines.push(...footer);
+              core.setOutput('message', lines.join('\n'));
+            };
+
+            // sources/<project>/...rst|md — project slugs match this tree
+            // (peft, ms-swift, LLaMA-Factory). Reject `..` and anything else.
+            const DOC_PATH = /^sources\/([A-Za-z0-9._-]+)\/[A-Za-z0-9._/-]+\.(rst|md)$/;
+
+            const matchDoc = (filename) => {
+              if (!filename || filename.includes('..')) {
+                return null;
+              }
+              const match = DOC_PATH.exec(filename);
+              return match ? match[1] : null;
+            };
+
+            const projectIndexUrl = (project) => {
+              const indexFile = path.join('site', 'sources', project, 'index.html');
+              if (!fs.existsSync(indexFile)) {
+                return null;
+              }
+              return `${siteRoot}sources/${project}/`;
+            };
+
+            try {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(number),
+              });
+
+              const projects = new Set();
+              for (const file of files) {
+                for (const name of [file.filename, file.previous_filename]) {
+                  const project = matchDoc(name);
+                  if (project) {
+                    projects.add(project);
+                  }
+                }
+              }
+
+              const linked = [...projects].sort().flatMap((project) => {
+                const url = projectIndexUrl(project);
+                return url ? [`- [\`${project}\`](${url})`] : [];
+              });
+
+              if (projects.size === 1) {
+                const project = [...projects][0];
+                const projectUrl = projectIndexUrl(project);
+                if (projectUrl) {
+                  write(projectUrl, [`也可打开[整站首页](${siteRoot})。`]);
+                  return;
+                }
+              }
+
+              if (projects.size > 1 && linked.length) {
+                write(siteRoot, ['本 PR 改动了多个项目：', ...linked]);
+                return;
+              }
+
+              write(siteRoot, []);
+            } catch (error) {
+              core.warning(
+                `Could not resolve landing page (${error.message}); linking to site root`,
+              );
+              core.setOutput('message', homepageMessage);
+            }
+
       - name: Deploy preview
         if: steps.pr.outputs.deploy == 'true'
         uses: peaceiris/actions-gh-pages@v4
@@ -97,8 +203,4 @@ jobs:
         with:
           header: docs-preview
           number: ${{ steps.pr.outputs.number }}
-          message: |
-            📖 **文档预览**：${{ steps.pr.outputs.base }}/pr-preview/pr-${{ steps.pr.outputs.number }}/
-
-            构建自 `${{ steps.pr.outputs.sha }}`，页面上线约需 1 分钟。
-            每次推送后自动更新，PR 关闭时自动清理。
+          message: ${{ steps.landing.outputs.message }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,16 @@ Here is how you can create a new docs:
 ## PR preview
 
 Every pull request gets a rendered preview of the whole site. Once the `Github Pages`
-build finishes (about 10 minutes), a bot comments the link on the PR:
+build finishes (about 10 minutes), a bot comments the link on the PR.
+
+If the PR changes documentation under exactly one `sources/<project>/` directory,
+the link opens that project's page:
+
+```
+https://ascend.github.io/docs/pr-preview/pr-<PR number>/sources/<project>/
+```
+
+Otherwise (no project docs, or more than one project) it opens the site homepage:
 
 ```
 https://ascend.github.io/docs/pr-preview/pr-<PR number>/


### PR DESCRIPTION
## 摘要

- 当 PR 仅改动一个 `sources/<project>/` 目录下的文档时，预览置顶评论的主链接改为该项目目录页（例如 `.../pr-142/sources/peft/`），不再一律指向整站首页；评论中仍保留次要的首页链接。
- 若 PR 未改动任何项目文档，或同时改动多个项目，主链接仍回退到整站首页；多项目 PR 会在评论中额外列出各项目目录页的单独链接。
- 仅当已下载的构建产物中存在对应 `index.html` 时才输出该链接，避免指向尚未生成的页面；算不出或页面不存在时回退首页。
