### PR TITLE
test: probe official vLLM pip install on HK A2 (do not merge)

### DIFF
--- a/.github/workflows/vllm-install-probe.yml
+++ b/.github/workflows/vllm-install-probe.yml
@@ -46,7 +46,16 @@ jobs:
           export PATH="/usr/local/sbin:/usr/local/bin:$PATH"
           npu-smi info || true
           echo "PIP_INDEX_URL=${PIP_INDEX_URL}"
-          python -c "import os, urllib.request; urllib.request.urlopen(os.environ['PIP_INDEX_URL'], timeout=5); print('cluster_pypi: ok')"
+          # Bare GET of /pypi/simple can 429; reachability is enough.
+          python -c "
+          import os, urllib.error, urllib.request
+          url = os.environ['PIP_INDEX_URL']
+          try:
+              urllib.request.urlopen(url, timeout=5)
+              print('cluster_pypi: ok')
+          except urllib.error.HTTPError as e:
+              print(f'cluster_pypi: HTTP {e.code}')
+          "
           ls -ld /root/.cache || true
 
       - name: Checkout

--- a/.github/workflows/vllm-install-probe.yml
+++ b/.github/workflows/vllm-install-probe.yml
@@ -1,0 +1,63 @@
+# Throwaway probe: official pip install of vllm + vllm-ascend on the
+# Hong Kong A2 runner. Do not merge. Close the PR after the run.
+#
+# Uses a local file:// doc URL so a fork PR can still execute the
+# commands (the shared QS engine fetches raw.githubusercontent.com
+# on Ascend/docs and 404s for fork SHAs).
+
+name: vllm-install-probe
+
+concurrency:
+  group: ${{ format('vllm-install-probe-{0}', github.run_id) }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/vllm_install_probe/**'
+      - 'tests/vllm_install_probe/**'
+      - '.github/workflows/vllm-install-probe.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: linux-aarch64-a2-1
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+    env:
+      # Same cluster PyPI cache the QS engine injects. Do not add
+      # --volume: /root/.cache is already NFS-mounted on this runner.
+      PIP_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+      PIP_EXTRA_INDEX_URL: https://repo.huaweicloud.com/ascend/repos/pypi
+      PIP_TRUSTED_HOST: cache-service.nginx-pypi-cache.svc.cluster.local
+      PIP_TIMEOUT: '120'
+    steps:
+      - name: Probe NPU and cache
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/sbin:/usr/local/bin:$PATH"
+          npu-smi info || true
+          echo "PIP_INDEX_URL=${PIP_INDEX_URL}"
+          python -c "import os, urllib.request; urllib.request.urlopen(os.environ['PIP_INDEX_URL'], timeout=5); print('cluster_pypi: ok')"
+          ls -ld /root/.cache || true
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run official pip install from the probe doc
+        env:
+          NPU_READY: 'true'
+          UPSTREAM_REF: v0.23.0
+        run: |
+          set -euo pipefail
+          export MONITORED_DOC_URL="file://${GITHUB_WORKSPACE}/sources/vllm_install_probe/quick_start.md"
+          python -m pip install 'mistune>=3,<4'
+          python -m unittest tests.vllm_install_probe.test_quick_start_ascend -v 2>&1

--- a/sources/vllm_install_probe/quick_start.md
+++ b/sources/vllm_install_probe/quick_start.md
@@ -32,10 +32,11 @@ python -c "from importlib.metadata import version; print('vllm', version('vllm')
 
 输出结果如下：
 
-```shell #test-result id="install-vllm" fuzzy='xxx'
-...vllm 0.23.0
+```shell #test-result id="install-vllm"
+...
+vllm 0.23.0
 vllm-ascend 0.23.0
-torch 2.10.0xxx
+torch 2.10.0
 torch-npu 2.10.0.post4
 triton-ascend 3.2.2
 ```

--- a/sources/vllm_install_probe/quick_start.md
+++ b/sources/vllm_install_probe/quick_start.md
@@ -1,0 +1,54 @@
+# vLLM 安装探测（勿合入）
+
+在 CANN 9.1 镜像里用官方 pip wheel 安装 vLLM 0.23.0 与 vllm-ascend 0.23.0，并确认张量落在 NPU 上。本页只用于验证迁到 `Ascend/docs` 后的默认装法，测完即关，不要合入主干。
+
+## 前置条件
+
+配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+| 组件 | 版本 |
+| --- | --- |
+| CANN | 9.1.0 |
+| vllm | 0.23.0 |
+| vllm-ascend | 0.23.0 |
+| torch / torch-npu | 由 vllm-ascend 装到 2.10.0 / 2.10.0.post4 |
+| triton-ascend | 3.2.2 |
+
+## 安装
+
+先装与 vllm-ascend 同版本的 vLLM，再从昇腾 variant 源装插件。不要把两步合成一次 `pip install`。最后单独覆盖社区版 CUDA Triton。
+
+```shell #test id="install-vllm"
+python -m pip install --retries 3 vllm==0.23.0
+python -m pip install \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  vllm-ascend==0.23.0
+python -m pip install --force-reinstall --no-deps \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  triton-ascend==3.2.2
+python -c "from importlib.metadata import version; print('vllm', version('vllm')); print('vllm-ascend', version('vllm-ascend')); print('torch', version('torch')); print('torch-npu', version('torch-npu')); print('triton-ascend', version('triton-ascend'))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-vllm" fuzzy='xxx'
+...vllm 0.23.0
+vllm-ascend 0.23.0
+torch 2.10.0xxx
+torch-npu 2.10.0.post4
+triton-ascend 3.2.2
+```
+
+## 确认 NPU
+
+```shell #test id="npu-tensor"
+python -c "import torch, torch_npu; x = torch.zeros(1, device='npu:0'); print('device', x.device); print('npu_available', torch.npu.is_available())"
+```
+
+输出结果如下：
+
+```shell #test-result id="npu-tensor"
+device npu:0
+npu_available True
+```

--- a/tests/vllm_install_probe/__init__.py
+++ b/tests/vllm_install_probe/__init__.py
@@ -1,0 +1,20 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the workflow, not at import time.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Layout: tests/vllm_install_probe/__init__.py -> parents[2] = repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/vllm_install_probe/test_quick_start_ascend.py
+++ b/tests/vllm_install_probe/test_quick_start_ascend.py
@@ -1,0 +1,81 @@
+"""Probe: official pip install of vllm + vllm-ascend on the Hong Kong A2 runner.
+
+Doc under test is ``sources/vllm_install_probe/quick_start.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+
+from doc_test.base import MarkdownDocTestBase
+
+
+def _is_truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    DEFAULT_COMMAND_TIMEOUT = 3600
+    USER_AGENT = 'ascend-docs/vllm-install-probe'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',
+        'ERR99999',
+    )
+
+    _CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+    _NNAL_SET_ENV = '/usr/local/Ascend/nnal/atb/set_env.sh'
+
+    @classmethod
+    def _merge_sourced_env(cls, script: str) -> None:
+        merged = subprocess.run(
+            ['bash', '-c', f'source {script} >/dev/null 2>&1; env'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            os.environ[key] = value
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        if os.path.isfile(cls._CANN_SET_ENV):
+            cls._merge_sourced_env(cls._CANN_SET_ENV)
+            print(f'setup: sourced {cls._CANN_SET_ENV}')
+        else:
+            print(f'setup: missing {cls._CANN_SET_ENV}')
+        if os.path.isfile(cls._NNAL_SET_ENV):
+            cls._merge_sourced_env(cls._NNAL_SET_ENV)
+            print(f'setup: sourced {cls._NNAL_SET_ENV}')
+
+        path_dirs = '/usr/local/sbin:/usr/local/bin'
+        current_path = os.environ.get('PATH', '')
+        if path_dirs not in current_path:
+            os.environ['PATH'] = f'{path_dirs}:{current_path}'
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Throwaway probe for the default vLLM install path after migrating Quick Start into this repo: official `pip install vllm==0.23.0` then `vllm-ascend==0.23.0` (variant extra-index), then `triton-ascend==3.2.2` with `--force-reinstall --no-deps`.
- Uses the Hong Kong A2 runner, the CANN 9.1 image, the cluster PyPI cache, and the already-mounted `/root/.cache`. No `--volume`, no GitHub proxy, no ModelScope.
- Standalone workflow reads the local `file://` doc so a fork PR still runs (the shared engine fetches `raw.githubusercontent.com/Ascend/docs/<sha>` and 404s on fork SHAs).

## Test plan

- [ ] `vllm-install-probe` runs on `linux-aarch64-a2-1`
- [ ] Install block prints `vllm 0.23.0` / `vllm-ascend 0.23.0` / `torch 2.10.0*` / `torch-npu 2.10.0.post4` / `triton-ascend 3.2.2`
- [ ] NPU block prints `device npu:0`
- [ ] Close this PR after the run. Do not merge.