### PR TITLE
[feature] 迁移 llm-compressor Quick Start 并接入看护

### DIFF
--- a/.github/workflows/llm_compressor-quick-start.yml
+++ b/.github/workflows/llm_compressor-quick-start.yml
@@ -1,0 +1,69 @@
+# llm-compressor quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+
+name: llm_compressor-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'llm_compressor-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Offset from peft's '30 */3 * * *' so the two jobs do not start
+    # on the same minute.
+    - cron: '50 */3 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/llm_compressor/**'
+      - 'tests/llm_compressor/**'
+
+permissions:
+  contents: read
+
+jobs:
+  llm_compressor-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-llm_compressor-*), artifacts
+      # (llm_compressor-quick-start-<run_id>) and the test working dir
+      # (workflows/tests/llm_compressor).
+      project: llm_compressor
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # 2 h budget. The smoke model is ~10 MB; the slow path is installing
+      # torch / torch_npu / llmcompressor from the cluster PyPI cache.
+      # Do not add a container bind-mount for /root/.cache: the runner
+      # NFS already persists that tree, and Hub models land in the default
+      # Hugging Face cache.
+      timeout_minutes: 120
+      upstream_repo: vllm-project/llm-compressor
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/llm_compressor/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/llm_compressor/quick_start.md
+      # cwd is the repo root inside the `workflows` checkout (matches
+      # engine template's `working-directory: workflows`); env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep lives in the test subclass's
+      # prepare_environment hook.
+      test_command: python -m unittest tests.llm_compressor.test_quick_start_ascend -v 2>&1

--- a/conf.py
+++ b/conf.py
@@ -71,7 +71,7 @@ language = 'zh_CN'
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
                     '.github', 'tests',
-                    # Included into sources/llm_compressor/index.md; excluding
+                    # Included into sources/llm_compressor/index.rst; excluding
                     # the file itself avoids a nested sidebar「快速开始」.
                     'sources/llm_compressor/quick_start.md']
 

--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,10 @@ language = 'zh_CN'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
-                    '.github', 'tests']
+                    '.github', 'tests',
+                    # Included into sources/llm_compressor/index.md; excluding
+                    # the file itself avoids a nested sidebar「快速开始」.
+                    'sources/llm_compressor/quick_start.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -250,6 +250,13 @@
          <div class="card-footer"><a href="https://github.com/ggerganov/llama.cpp">官方链接</a><span class="split">|</span><a href="sources/llama_cpp/install.html">安装指南</a><span class="split">|</span><a href="sources/llama_cpp/quick_start.html">快速上手</a></div>
       </div>
 
+      <!-- llm-compressor -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/vllm-ascend.png')"></div><h3 class="card-title">llm-compressor</h3></div>
+         <p class="card-desc">面向 vLLM 部署的模型压缩库，在昇腾上完成 GPTQ 量化与 NPU 前向。</p>
+         <div class="card-footer"><a href="https://github.com/vllm-project/llm-compressor">官方链接</a><span class="split">|</span><a href="https://docs.vllm.ai/projects/llm-compressor/en/latest/">文档中心</a><span class="split">|</span><a href="sources/llm_compressor/index.html">快速上手</a></div>
+      </div>
+
       <!-- LMDeploy：官方文档站已含昇腾说明，外链跳转，不再本地编译 -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/lm-deploy.png')"></div><h3 class="card-title">lmdeploy</h3></div>
@@ -426,6 +433,7 @@
    :caption: 🚀 推理与服务
 
    sources/llama_cpp/index.rst
+   sources/llm_compressor/index.md
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst
    sources/sentence_transformers/index.rst

--- a/index.rst
+++ b/index.rst
@@ -433,7 +433,7 @@
    :caption: 🚀 推理与服务
 
    sources/llama_cpp/index.rst
-   sources/llm_compressor/index.md
+   sources/llm_compressor/index.rst
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst
    sources/sentence_transformers/index.rst

--- a/sources/llm_compressor/index.md
+++ b/sources/llm_compressor/index.md
@@ -1,0 +1,6 @@
+# llm-compressor
+
+llm-compressor 通用文档由 vLLM 项目维护。本页收录在昇腾 NPU 上第一次用 GPTQ 做完一次量化并前向的步骤。
+
+```{include} quick_start.md
+```

--- a/sources/llm_compressor/index.md
+++ b/sources/llm_compressor/index.md
@@ -1,6 +1,0 @@
-# llm-compressor
-
-llm-compressor 通用文档由 vLLM 项目维护。本页收录在昇腾 NPU 上第一次用 GPTQ 做完一次量化并前向的步骤。
-
-```{include} quick_start.md
-```

--- a/sources/llm_compressor/index.rst
+++ b/sources/llm_compressor/index.rst
@@ -1,0 +1,2 @@
+.. include:: quick_start.md
+   :parser: myst_parser.sphinx_

--- a/sources/llm_compressor/quick_start.md
+++ b/sources/llm_compressor/quick_start.md
@@ -1,0 +1,261 @@
+# 快速开始
+
+在单卡昇腾上安装 llm-compressor，对公开小模型做一次 W4A16 GPTQ，再保存、重载并完成一次前向。
+
+## 前置条件
+
+### 硬件
+
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。
+
+### 软件
+
+| 类别 | 要求 |
+| --- | --- |
+| CANN | toolkit + 驱动固件已安装，并可 `source set_env.sh` |
+| Python | 3.12 |
+| PyTorch | `torch==2.10.0` 与 `torch_npu==2.10.0.post4`，见下文安装 |
+| llm-compressor | 从 PyPI 安装发布版，见下文 |
+| 模型 | [nm-testing/tinysmokeqwen3](https://huggingface.co/nm-testing/tinysmokeqwen3)（约 10 MB） |
+
+配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。
+
+## 1. 加载 CANN 环境
+
+新开终端后 CANN 变量不会自动生效。常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+export PATH=/usr/local/sbin:$PATH
+```
+
+## 2. 检查环境是否就绪
+
+### 2.1 确认 NPU 在线
+
+下面确认驱动能看到设备。表格中的功耗、HBM 占用每次不同，不必与样例逐字一致。
+
+```shell
+npu-smi info
+```
+
+如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
+
+### 2.2 确认工具可用
+
+下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
+
+```shell #test id="check-tools"
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-tools"
+...
+Python 3.12...
+```
+
+## 3. 安装 PyTorch NPU 栈
+
+昇腾上的 `torch_npu` 要从华为 PyPI 额外索引安装，并钉死与 CANN 9.1.0 匹配的版本。`numpy` 和 `pyyaml` 也要一起装：缺了会在 `import torch_npu` 之前失败。
+
+```shell #test id="install-torch"
+python -m pip install --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://repo.huaweicloud.com/ascend/repos/pypi \
+  torch==2.10.0 torch_npu==2.10.0.post4 numpy pyyaml
+python -c "import numpy, yaml, torch, torch_npu; print('torch', torch.__version__); print('torch_npu', torch_npu.__version__); print('npu_available', torch.npu.is_available())"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-torch"
+...
+torch 2.10.0...
+torch_npu 2.10.0.post4
+npu_available True
+```
+
+`npu_available` 必须是 `True`。`torch` 版本串可能带 `+cpu` 后缀，以 `npu_available True` 为准。
+
+## 4. 安装 llm-compressor
+
+将 `<UPSTREAM_REF>` 换成目标 PyPI 版本号（撰写时最新正式版是 `0.13.0`）。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+```shell #test id="install-llmcompressor" load="upstream_ref>>UPSTREAM_REF"
+python -m pip install --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://repo.huaweicloud.com/ascend/repos/pypi \
+  llmcompressor==<UPSTREAM_REF> torch==2.10.0 torch_npu==2.10.0.post4
+python -c "import llmcompressor; print('llmcompressor', llmcompressor.__version__)"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-llmcompressor"
+...
+llmcompressor ...
+```
+
+## 5. 在 NPU 上做一次单层 W4A16 GPTQ
+
+下面从 Hugging Face 下载公开小模型 `nm-testing/tinysmokeqwen3`（不必事先准备权重），用 8 条本地校准文本只量化第 3 层的 `q_proj`。`oneshot` 把压缩后的模型写到本机 `~/llm-compressor-work/compressed`，随后从该目录重载并做一次前向。
+
+保存为 `oneshot_forward.py`：
+
+```python
+from pathlib import Path
+
+import torch
+import torch_npu
+from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from datasets import Dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+model_id = "nm-testing/tinysmokeqwen3"
+device = "npu:0"
+compressed_dir = Path.home() / "llm-compressor-work" / "compressed"
+
+model = AutoModelForCausalLM.from_pretrained(model_id).to(device)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+ds = Dataset.from_dict(
+    {
+        "text": [
+            "The quick brown fox jumps over the lazy dog.",
+            "Quantization maps weights to fewer bits.",
+            "Ascend NPU runs this oneshot calibration.",
+            "A short sentence is enough for a smoke test.",
+        ]
+        * 2
+    }
+)
+recipe = GPTQModifier(
+    ignore=["lm_head"],
+    config_groups={
+        "group_0": QuantizationScheme(
+            targets=["re:.*model.layers.2.self_attn.q_proj$"],
+            weights=QuantizationArgs(num_bits=4, strategy="group", group_size=32),
+        )
+    },
+)
+torch.accelerator.max_memory_allocated = lambda device=None: 0
+torch.accelerator.get_memory_info = lambda device=None: (0, 1)
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    num_calibration_samples=8,
+    max_seq_length=64,
+    output_dir=str(compressed_dir),
+)
+
+reloaded = AutoModelForCausalLM.from_pretrained(compressed_dir).to(device)
+inputs = tokenizer("hello", return_tensors="pt").to(device)
+logits = reloaded(**inputs).logits
+qc = reloaded.config.quantization_config
+inner = getattr(qc, "quantization_config", qc)
+group0 = inner.config_groups["group_0"]
+print("LLM_COMPRESSOR_WORKLOAD_DEVICE=npu:0")
+print("weight_num_bits", group0.weights.num_bits)
+print("targeted", hasattr(reloaded.model.layers[2].self_attn.q_proj, "quantization_scheme"))
+print("lm_head_quantized", hasattr(reloaded.lm_head, "quantization_scheme"))
+print("logits.device", logits.device)
+```
+
+<!--
+```shell #test-setup
+cat > oneshot_forward.py <<'PY'
+from pathlib import Path
+
+import torch
+import torch_npu
+from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from datasets import Dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+model_id = "nm-testing/tinysmokeqwen3"
+device = "npu:0"
+# oneshot 写入量化结果的目录，不是事先准备好的权重路径
+compressed_dir = Path.home() / "llm-compressor-work" / "compressed"
+
+model = AutoModelForCausalLM.from_pretrained(model_id).to(device)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+ds = Dataset.from_dict(
+    {
+        "text": [
+            "The quick brown fox jumps over the lazy dog.",
+            "Quantization maps weights to fewer bits.",
+            "Ascend NPU runs this oneshot calibration.",
+            "A short sentence is enough for a smoke test.",
+        ]
+        * 2
+    }
+)
+recipe = GPTQModifier(
+    ignore=["lm_head"],
+    config_groups={
+        "group_0": QuantizationScheme(
+            targets=["re:.*model.layers.2.self_attn.q_proj$"],
+            weights=QuantizationArgs(num_bits=4, strategy="group", group_size=32),
+        )
+    },
+)
+torch.accelerator.max_memory_allocated = lambda device=None: 0
+torch.accelerator.get_memory_info = lambda device=None: (0, 1)
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    num_calibration_samples=8,
+    max_seq_length=64,
+    output_dir=str(compressed_dir),
+)
+
+reloaded = AutoModelForCausalLM.from_pretrained(compressed_dir).to(device)
+inputs = tokenizer("hello", return_tensors="pt").to(device)
+logits = reloaded(**inputs).logits
+qc = reloaded.config.quantization_config
+inner = getattr(qc, "quantization_config", qc)
+group0 = inner.config_groups["group_0"]
+print("LLM_COMPRESSOR_WORKLOAD_DEVICE=npu:0")
+print("weight_num_bits", group0.weights.num_bits)
+print("targeted", hasattr(reloaded.model.layers[2].self_attn.q_proj, "quantization_scheme"))
+print("lm_head_quantized", hasattr(reloaded.lm_head, "quantization_scheme"))
+print("logits.device", logits.device)
+PY
+```
+-->
+
+运行：
+
+```shell #test id="oneshot-forward"
+python oneshot_forward.py
+```
+
+输出结果如下：
+
+```shell #test-result id="oneshot-forward"
+...
+LLM_COMPRESSOR_WORKLOAD_DEVICE=npu:0
+weight_num_bits 4
+targeted True
+lm_head_quantized False
+logits.device npu:0
+```
+
+进程须退出码为 0，且 `logits.device` 必须是 `npu:0`；若打印 `cpu`，那是静默回退，视为失败。

--- a/sources/llm_compressor/quick_start.md
+++ b/sources/llm_compressor/quick_start.md
@@ -1,14 +1,14 @@
-## 快速开始
+# llm-compressor
 
 在单卡昇腾上安装 llm-compressor，对公开小模型做一次 W4A16 GPTQ，再保存、重载并完成一次前向。
 
-### 前置条件
+## 前置条件
 
-#### 硬件
+### 硬件
 
 Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。
 
-#### 软件
+### 软件
 
 | 类别 | 要求 |
 | --- | --- |
@@ -22,7 +22,7 @@ Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为�
 
 阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。
 
-### 1. 加载 CANN 环境
+## 1. 加载 CANN 环境
 
 新开终端后 CANN 变量不会自动生效。常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。
 
@@ -31,9 +31,9 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 export PATH=/usr/local/sbin:$PATH
 ```
 
-### 2. 检查环境是否就绪
+## 2. 检查环境是否就绪
 
-#### 2.1 确认 NPU 在线
+### 2.1 确认 NPU 在线
 
 下面确认驱动能看到设备。表格中的功耗、HBM 占用每次不同，不必与样例逐字一致。
 
@@ -43,7 +43,7 @@ npu-smi info
 
 如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
 
-#### 2.2 确认工具可用
+### 2.2 确认工具可用
 
 下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
 
@@ -60,7 +60,7 @@ python --version
 Python 3.12...
 ```
 
-### 3. 安装 PyTorch NPU 栈
+## 3. 安装 PyTorch NPU 栈
 
 昇腾上的 `torch_npu` 要从华为 PyPI 额外索引安装，并钉死与 CANN 9.1.0 匹配的版本。`numpy` 和 `pyyaml` 也要一起装：缺了会在 `import torch_npu` 之前失败。
 
@@ -82,7 +82,7 @@ npu_available True
 
 `npu_available` 必须是 `True`。`torch` 版本串可能带 `+cpu` 后缀，以 `npu_available True` 为准。
 
-### 4. 安装 llm-compressor
+## 4. 安装 llm-compressor
 
 将 `<UPSTREAM_REF>` 换成目标 PyPI 版本号（撰写时最新正式版是 `0.13.0`）。
 
@@ -106,7 +106,7 @@ python -c "import llmcompressor; print('llmcompressor', llmcompressor.__version_
 llmcompressor ...
 ```
 
-### 5. 在 NPU 上做一次单层 W4A16 GPTQ
+## 5. 在 NPU 上做一次单层 W4A16 GPTQ
 
 下面从 Hugging Face 下载公开小模型 `nm-testing/tinysmokeqwen3`（不必事先准备权重），用 8 条本地校准文本只量化第 3 层的 `q_proj`。`oneshot` 把压缩后的模型写到本机 `~/llm-compressor-work/compressed`，随后从该目录重载并做一次前向。
 

--- a/sources/llm_compressor/quick_start.md
+++ b/sources/llm_compressor/quick_start.md
@@ -1,14 +1,14 @@
-# 快速开始
+## 快速开始
 
 在单卡昇腾上安装 llm-compressor，对公开小模型做一次 W4A16 GPTQ，再保存、重载并完成一次前向。
 
-## 前置条件
+### 前置条件
 
-### 硬件
+#### 硬件
 
 Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。
 
-### 软件
+#### 软件
 
 | 类别 | 要求 |
 | --- | --- |
@@ -22,7 +22,7 @@ Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为�
 
 阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。
 
-## 1. 加载 CANN 环境
+### 1. 加载 CANN 环境
 
 新开终端后 CANN 变量不会自动生效。常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。
 
@@ -31,9 +31,9 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 export PATH=/usr/local/sbin:$PATH
 ```
 
-## 2. 检查环境是否就绪
+### 2. 检查环境是否就绪
 
-### 2.1 确认 NPU 在线
+#### 2.1 确认 NPU 在线
 
 下面确认驱动能看到设备。表格中的功耗、HBM 占用每次不同，不必与样例逐字一致。
 
@@ -43,7 +43,7 @@ npu-smi info
 
 如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
 
-### 2.2 确认工具可用
+#### 2.2 确认工具可用
 
 下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
 
@@ -60,7 +60,7 @@ python --version
 Python 3.12...
 ```
 
-## 3. 安装 PyTorch NPU 栈
+### 3. 安装 PyTorch NPU 栈
 
 昇腾上的 `torch_npu` 要从华为 PyPI 额外索引安装，并钉死与 CANN 9.1.0 匹配的版本。`numpy` 和 `pyyaml` 也要一起装：缺了会在 `import torch_npu` 之前失败。
 
@@ -82,7 +82,7 @@ npu_available True
 
 `npu_available` 必须是 `True`。`torch` 版本串可能带 `+cpu` 后缀，以 `npu_available True` 为准。
 
-## 4. 安装 llm-compressor
+### 4. 安装 llm-compressor
 
 将 `<UPSTREAM_REF>` 换成目标 PyPI 版本号（撰写时最新正式版是 `0.13.0`）。
 
@@ -106,7 +106,7 @@ python -c "import llmcompressor; print('llmcompressor', llmcompressor.__version_
 llmcompressor ...
 ```
 
-## 5. 在 NPU 上做一次单层 W4A16 GPTQ
+### 5. 在 NPU 上做一次单层 W4A16 GPTQ
 
 下面从 Hugging Face 下载公开小模型 `nm-testing/tinysmokeqwen3`（不必事先准备权重），用 8 条本地校准文本只量化第 3 层的 `q_proj`。`oneshot` 把压缩后的模型写到本机 `~/llm-compressor-work/compressed`，随后从该目录重载并做一次前向。
 

--- a/sources/llm_compressor/quick_start.md
+++ b/sources/llm_compressor/quick_start.md
@@ -167,7 +167,6 @@ logits = reloaded(**inputs).logits
 qc = reloaded.config.quantization_config
 inner = getattr(qc, "quantization_config", qc)
 group0 = inner.config_groups["group_0"]
-print("LLM_COMPRESSOR_WORKLOAD_DEVICE=npu:0")
 print("weight_num_bits", group0.weights.num_bits)
 print("targeted", hasattr(reloaded.model.layers[2].self_attn.q_proj, "quantization_scheme"))
 print("lm_head_quantized", hasattr(reloaded.lm_head, "quantization_scheme"))
@@ -190,7 +189,6 @@ from llmcompressor.modifiers.gptq import GPTQModifier
 
 model_id = "nm-testing/tinysmokeqwen3"
 device = "npu:0"
-# oneshot 写入量化结果的目录，不是事先准备好的权重路径
 compressed_dir = Path.home() / "llm-compressor-work" / "compressed"
 
 model = AutoModelForCausalLM.from_pretrained(model_id).to(device)
@@ -232,7 +230,6 @@ logits = reloaded(**inputs).logits
 qc = reloaded.config.quantization_config
 inner = getattr(qc, "quantization_config", qc)
 group0 = inner.config_groups["group_0"]
-print("LLM_COMPRESSOR_WORKLOAD_DEVICE=npu:0")
 print("weight_num_bits", group0.weights.num_bits)
 print("targeted", hasattr(reloaded.model.layers[2].self_attn.q_proj, "quantization_scheme"))
 print("lm_head_quantized", hasattr(reloaded.lm_head, "quantization_scheme"))
@@ -251,7 +248,6 @@ python oneshot_forward.py
 
 ```shell #test-result id="oneshot-forward"
 ...
-LLM_COMPRESSOR_WORKLOAD_DEVICE=npu:0
 weight_num_bits 4
 targeted True
 lm_head_quantized False

--- a/sources/llm_compressor/quick_start.md
+++ b/sources/llm_compressor/quick_start.md
@@ -18,13 +18,11 @@ Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为�
 | llm-compressor | 从 PyPI 安装发布版，见下文 |
 | 模型 | [nm-testing/tinysmokeqwen3](https://huggingface.co/nm-testing/tinysmokeqwen3)（约 10 MB） |
 
-配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
-
-阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。推荐配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
 
 ## 1. 加载 CANN 环境
 
-新开终端后 CANN 变量不会自动生效。常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。
+常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。
 
 ```shell
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
@@ -34,8 +32,6 @@ export PATH=/usr/local/sbin:$PATH
 ## 2. 检查环境是否就绪
 
 ### 2.1 确认 NPU 在线
-
-下面确认驱动能看到设备。表格中的功耗、HBM 占用每次不同，不必与样例逐字一致。
 
 ```shell
 npu-smi info
@@ -80,8 +76,6 @@ torch_npu 2.10.0.post4
 npu_available True
 ```
 
-`npu_available` 必须是 `True`。`torch` 版本串可能带 `+cpu` 后缀，以 `npu_available True` 为准。
-
 ## 4. 安装 llm-compressor
 
 将 `<UPSTREAM_REF>` 换成目标 PyPI 版本号（撰写时最新正式版是 `0.13.0`）。
@@ -108,7 +102,7 @@ llmcompressor ...
 
 ## 5. 在 NPU 上做一次单层 W4A16 GPTQ
 
-下面从 Hugging Face 下载公开小模型 `nm-testing/tinysmokeqwen3`（不必事先准备权重），用 8 条本地校准文本只量化第 3 层的 `q_proj`。`oneshot` 把压缩后的模型写到本机 `~/llm-compressor-work/compressed`，随后从该目录重载并做一次前向。
+下面从 Hugging Face 下载公开小模型 `nm-testing/tinysmokeqwen3`，用 8 条本地校准文本只量化第 3 层的 `q_proj`。`oneshot` 把压缩后的模型写到本机 `~/llm-compressor-work/compressed`，随后从该目录重载并做一次前向。
 
 保存为 `oneshot_forward.py`：
 
@@ -254,4 +248,4 @@ lm_head_quantized False
 logits.device npu:0
 ```
 
-进程须退出码为 0，且 `logits.device` 必须是 `npu:0`；若打印 `cpu`，那是静默回退，视为失败。
+进程须退出码为 0，且 `logits.device` 必须是 `npu:0`；若打印 `cpu`，则为静默回退，视为失败。

--- a/tests/llm_compressor/__init__.py
+++ b/tests/llm_compressor/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent ``__init__.py``
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/llm_compressor/__init__.py -> parents[0]=tests/llm_compressor,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/llm_compressor/test_quick_start_ascend.py
+++ b/tests/llm_compressor/test_quick_start_ascend.py
@@ -1,0 +1,111 @@
+"""Quick-start test: doc under test is ``sources/llm_compressor/quick_start.md``.
+
+Run: ``python -m unittest tests.llm_compressor.test_quick_start_ascend -v 2>&1``
+
+Env (injected by the engine ``quick-start-template.yml``, triggered by
+``llm_compressor-quick-start.yml``): ``MONITORED_DOC_URL``, ``UPSTREAM_REF``,
+``NPU_READY=true`` (otherwise the class is skipped).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    ensure_safetensors,
+    purge_huggingface_corrupt,
+    report_huggingface_state,
+    resolve_huggingface_cache,
+)
+
+
+def _is_truthy(value: str | None) -> bool:
+    """``'true'`` -> True (case-insensitive); anything else (including unset) -> False."""
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    """Return True when ``NPU_READY=true`` is set, releasing the skip."""
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    """End-to-end test: fetch doc -> validate contract -> run ``#test-setup``
+    / ``#test`` in order -> compare against ``#test-result``."""
+
+    DEFAULT_COMMAND_TIMEOUT = 3600
+    USER_AGENT = 'ascend-docs/quick-start'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'HostRegisterError',
+        'ERR99999',  # CANN sentinel for unrecoverable runtime failure
+    )
+
+    _CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+    _MODEL_ID = 'nm-testing/tinysmokeqwen3'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN env once so later ``bash -c`` blocks inherit it.
+
+        Class-level setup: run once per test class, triggered by
+        ``setUpClass``. Each labeled fence is a new subprocess, so a
+        ``source set_env.sh`` block in the document does not persist.
+
+        Merge is overwrite, not ``setdefault``: the container image may
+        already ship ``LD_LIBRARY_PATH``, which would otherwise hide the
+        CANN increment from ``set_env.sh``.
+        """
+        if os.path.isfile(cls._CANN_SET_ENV):
+            merged = subprocess.run(
+                ['bash', '-c', f'source {cls._CANN_SET_ENV} >/dev/null 2>&1; env'],
+                capture_output=True, text=True, check=True,
+            )
+            for line in merged.stdout.splitlines():
+                if '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                os.environ[key] = value
+            print('setup: sourced CANN env from set_env.sh')
+        else:
+            print(
+                f'setup: skipping CANN env source ({cls._CANN_SET_ENV} not present)'
+            )
+
+        path_dirs = '/usr/local/sbin:/usr/local/bin'
+        current_path = os.environ.get('PATH', '')
+        if path_dirs not in current_path:
+            os.environ['PATH'] = f'{path_dirs}:{current_path}'
+
+        ensure_safetensors()
+        report_huggingface_state(cls._MODEL_ID)
+        purge_huggingface_corrupt(resolve_huggingface_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing when
+        ``NPU_READY`` is unset.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Run the full pre_process -> parse -> execute -> post_process flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- 把 `llm-compressor` 昇腾 Quick Start 迁到 `sources/llm_compressor/`。模型走 Hugging Face `nm-testing/tinysmokeqwen3`，工作负载预期含 `npu:0`。
- 接入共享引擎：薄触发器 `llm_compressor-quick-start.yml`（不传 `container_options` / `--volume`）+ `tests/llm_compressor` 子类；首页推理区增加卡片和 toctree。
