### PR TITLE
[feature] 迁移 bitsandbytes Quick Start 并接入看护

### DIFF
--- a/.github/workflows/bitsandbytes-quick-start.yml
+++ b/.github/workflows/bitsandbytes-quick-start.yml
@@ -1,0 +1,68 @@
+# bitsandbytes quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+
+name: bitsandbytes-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'bitsandbytes-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Offset from peft's '30 */3 * * *' so the two jobs do not start
+    # on the same minute.
+    - cron: '40 */3 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/bitsandbytes/**'
+      - 'tests/bitsandbytes/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bitsandbytes-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-bitsandbytes-*), artifacts
+      # (bitsandbytes-quick-start-<run_id>) and the test working dir
+      # (workflows/tests/bitsandbytes).
+      project: bitsandbytes
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # 90 min budget. No Hub model: the slow path is installing torch /
+      # torch_npu / bitsandbytes from the cluster PyPI cache, then a
+      # tiny Linear4bit forward. Do not add a container bind-mount for
+      # /root/.cache: the runner NFS already persists that tree.
+      timeout_minutes: 90
+      upstream_repo: bitsandbytes-foundation/bitsandbytes
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/bitsandbytes/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/bitsandbytes/quick_start.md
+      # cwd is the repo root inside the `workflows` checkout (matches
+      # engine template's `working-directory: workflows`); env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep lives in the test subclass's
+      # prepare_environment hook.
+      test_command: python -m unittest tests.bitsandbytes.test_quick_start_ascend -v 2>&1

--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,10 @@ language = 'zh_CN'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
-                    '.github', 'tests']
+                    '.github', 'tests',
+                    # Included into sources/bitsandbytes/index.rst; excluding
+                    # the file itself avoids a nested sidebar「快速开始」.
+                    'sources/bitsandbytes/quick_start.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -243,6 +243,13 @@
    <h2 class="scene-header">🚀 高性能推理与服务</h2>
    <div class="grid-container">
 
+      <!-- bitsandbytes -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/huggingface.png')"></div><h3 class="card-title">bitsandbytes</h3></div>
+         <p class="card-desc">8-bit / 4-bit 量化库。本文在单卡昇腾上跑通默认后端的 NF4 Linear4bit 前向。</p>
+         <div class="card-footer"><a href="https://github.com/bitsandbytes-foundation/bitsandbytes">官方链接</a><span class="split">|</span><a href="https://huggingface.co/docs/bitsandbytes">文档中心</a><span class="split">|</span><a href="sources/bitsandbytes/index.html">快速上手</a></div>
+      </div>
+
       <!-- llama.cpp -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/llama_cpp.png')"></div><h3 class="card-title">llama.cpp</h3></div>
@@ -425,6 +432,7 @@
    :hidden:
    :caption: 🚀 推理与服务
 
+   sources/bitsandbytes/index.rst
    sources/llama_cpp/index.rst
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst

--- a/sources/bitsandbytes/index.rst
+++ b/sources/bitsandbytes/index.rst
@@ -1,0 +1,2 @@
+.. include:: quick_start.md
+   :parser: myst_parser.sphinx_

--- a/sources/bitsandbytes/quick_start.md
+++ b/sources/bitsandbytes/quick_start.md
@@ -1,0 +1,188 @@
+# bitsandbytes
+
+在单卡昇腾上安装 bitsandbytes，用默认后端完成一次 NF4 `Linear4bit` 前向。
+
+## 前置条件
+
+### 硬件
+
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。
+
+### 软件
+
+
+| 类别           | 要求                                              |
+| ------------ | ----------------------------------------------- |
+| CANN         | toolkit + 驱动固件已安装，并可 `source set_env.sh`        |
+| Python       | 3.12                                            |
+| PyTorch      | `torch==2.9.0` 与 `torch_npu==2.9.0.post2`，见下文安装 |
+| bitsandbytes | 从 PyPI 安装发布版，见下文                                |
+
+
+配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。
+
+## 1. 加载 CANN 环境
+
+新开终端后 CANN 变量不会自动生效。常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+export PATH=/usr/local/sbin:$PATH
+```
+
+
+
+## 2. 检查环境是否就绪
+
+
+
+### 2.1 确认 NPU 在线
+
+下面确认驱动能看到设备。表格中的功耗、HBM 占用每次不同，不必与样例逐字一致。
+
+```shell
+npu-smi info
+```
+
+如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
+
+### 2.2 确认工具可用
+
+下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
+
+```shell #test id="check-tools"
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-tools"
+...
+Python 3.12...
+```
+
+
+
+## 3. 安装 PyTorch NPU 栈
+
+昇腾上的 `torch_npu` 要从华为 PyPI 额外索引安装，并钉死与 CANN 匹配的版本。`numpy` 和 `pyyaml` 也要一起装：`torch_npu` 的 wheel 没有声明这两项依赖，缺了会在显式 `import torch_npu` 之前失败。
+
+```shell #test id="install-torch"
+python -m pip install --extra-index-url https://repo.huaweicloud.com/ascend/repos/pypi \
+  torch==2.9.0 torch_npu==2.9.0.post2 numpy pyyaml
+python -c "import numpy, yaml, torch, torch_npu; print('torch', torch.__version__); print('torch_npu', torch_npu.__version__); print('npu_available', torch.npu.is_available())"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-torch"
+...
+torch 2.9.0...
+torch_npu 2.9.0.post2
+npu_available True
+```
+
+`npu_available` 必须是 `True`。`False` 时不要继续，先查 CANN、驱动和可见设备。
+
+## 4. 安装 bitsandbytes
+
+将 `<UPSTREAM_REF>` 换成目标 PyPI 版本号（撰写时最新正式版是 `0.50.2`）。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+```shell #test id="install-bnb" load="upstream_ref>>UPSTREAM_REF"
+python -m pip install bitsandbytes==<UPSTREAM_REF>
+python -c "import bitsandbytes as bnb; import bitsandbytes.cextension as ce; print('bitsandbytes', bnb.__version__); print('BNB_BACKEND', ce.BNB_BACKEND); print('lib', type(ce.lib).__name__)"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-bnb"
+...
+bitsandbytes ...
+BNB_BACKEND CPU
+lib BNBNativeLibrary
+```
+
+
+
+## 5. 在 NPU 上做一次 NF4 Linear4bit 前向
+
+下面在 CPU 上构造 `Linear4bit(64, 32)`，搬到 `npu:0` 量化，再用 float16 输入做一次前向。进程须退出码为 0，且 `out.device` 必须是 `npu:0`；若打印 `cpu`，那是静默回退，视为失败。
+
+保存为 `nf4_forward.py`：
+
+```python
+import torch
+import torch_npu
+import bitsandbytes as bnb
+
+layer = bnb.nn.Linear4bit(
+    64, 32, bias=False, compute_dtype=torch.float16, quant_type="nf4",
+    compress_statistics=False,
+)
+layer = layer.to("npu:0")
+x = torch.randn(4, 64, dtype=torch.float16, device="npu:0")
+out = layer(x)
+weight = layer.weight
+print("weight.device", weight.device)
+print("weight.dtype", weight.dtype)
+print("weight.bnb_quantized", weight.bnb_quantized)
+print("out.device", out.device)
+print("out.shape", tuple(out.shape))
+print("out.dtype", out.dtype)
+print("NF4 forward on Ascend NPU: OK")
+```
+
+<!--
+```shell #test-setup
+cat > nf4_forward.py <<'PY'
+import torch
+import torch_npu
+import bitsandbytes as bnb
+
+layer = bnb.nn.Linear4bit(
+    64, 32, bias=False, compute_dtype=torch.float16, quant_type="nf4",
+    compress_statistics=False,
+)
+layer = layer.to("npu:0")
+x = torch.randn(4, 64, dtype=torch.float16, device="npu:0")
+out = layer(x)
+weight = layer.weight
+print("weight.device", weight.device)
+print("weight.dtype", weight.dtype)
+print("weight.bnb_quantized", weight.bnb_quantized)
+print("out.device", out.device)
+print("out.shape", tuple(out.shape))
+print("out.dtype", out.dtype)
+print("NF4 forward on Ascend NPU: OK")
+PY
+```
+-->
+
+运行：
+
+```shell #test id="nf4-forward"
+python nf4_forward.py
+```
+
+输出结果如下：
+
+```shell #test-result id="nf4-forward"
+weight.device npu:0
+weight.dtype torch.uint8
+weight.bnb_quantized True
+out.device npu:0
+out.shape (4, 32)
+out.dtype torch.float16
+NF4 forward on Ascend NPU: OK
+```
+

--- a/tests/bitsandbytes/__init__.py
+++ b/tests/bitsandbytes/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+    * unittest treats ``tests/`` as a package; the parent ``__init__.py``
+      executes before any submodule import.
+    * It runs before ``tests/test_*.py`` import, which is the earliest
+      opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/bitsandbytes/__init__.py -> parents[0]=tests/bitsandbytes,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/bitsandbytes/test_quick_start_ascend.py
+++ b/tests/bitsandbytes/test_quick_start_ascend.py
@@ -1,0 +1,102 @@
+"""Quick-start test: doc under test is ``sources/bitsandbytes/quick_start.md``.
+
+Run: ``python -m unittest tests.bitsandbytes.test_quick_start_ascend -v 2>&1``
+
+Env (injected by the engine ``quick-start-template.yml``, triggered by
+``bitsandbytes-quick-start.yml``): ``MONITORED_DOC_URL``, ``UPSTREAM_REF``,
+``NPU_READY=true`` (otherwise the class is skipped).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+
+from doc_test.base import MarkdownDocTestBase
+
+
+def _is_truthy(value: str | None) -> bool:
+    """``'true'`` -> True (case-insensitive); anything else (including unset) -> False."""
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    """Return True when ``NPU_READY=true`` is set, releasing the skip."""
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    """End-to-end test: fetch doc -> validate contract -> run ``#test-setup``
+    / ``#test`` in order -> compare against ``#test-result``."""
+
+    DEFAULT_COMMAND_TIMEOUT = 3600
+    USER_AGENT = 'ascend-docs/quick-start'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'HostRegisterError',
+        'ERR99999',  # CANN sentinel for unrecoverable runtime failure
+    )
+
+    _CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN env once so later ``bash -c`` blocks inherit it.
+
+        Class-level setup: run once per test class, triggered by
+        ``setUpClass``. Each labeled fence is a new subprocess, so a
+        ``source set_env.sh`` block in the document does not persist.
+
+        Merge is overwrite, not ``setdefault``: the container image may
+        already ship ``LD_LIBRARY_PATH``, which would otherwise hide the
+        CANN increment from ``set_env.sh``.
+        """
+        if os.path.isfile(cls._CANN_SET_ENV):
+            merged = subprocess.run(
+                ['bash', '-c', f'source {cls._CANN_SET_ENV} >/dev/null 2>&1; env'],
+                capture_output=True, text=True, check=True,
+            )
+            for line in merged.stdout.splitlines():
+                if '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                os.environ[key] = value
+            print('setup: sourced CANN env from set_env.sh')
+        else:
+            print(
+                f'setup: skipping CANN env source ({cls._CANN_SET_ENV} not present)'
+            )
+
+        path_dirs = '/usr/local/sbin:/usr/local/bin'
+        current_path = os.environ.get('PATH', '')
+        if path_dirs not in current_path:
+            os.environ['PATH'] = f'{path_dirs}:{current_path}'
+
+        os.environ['PYTHONNOUSERSITE'] = '1'
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing when
+        ``NPU_READY`` is unset.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Run the full pre_process -> parse -> execute -> post_process flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
把 bitsandbytes 的昇腾 Quick Start 迁到本仓，并接入已有的 quick-start 看护引擎。文档在单卡上跑通默认后端的 NF4 Linear4bit 前向，薄触发器走香港 A2，不带源仓的代理、ModelScope 和 --volume。