### PR TITLE
[feature] 迁移 aibrix Quick Start 并接入看护

### DIFF
--- a/.github/workflows/aibrix-quick-start.yml
+++ b/.github/workflows/aibrix-quick-start.yml
@@ -1,0 +1,67 @@
+# aibrix quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+
+name: aibrix-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'aibrix-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Offset from peft's '30 */3 * * *' and llama_cpp's '45 */3 * * *'.
+    - cron: '10 */3 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/aibrix/**'
+      - 'tests/aibrix/**'
+
+permissions:
+  contents: read
+
+jobs:
+  aibrix-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-aibrix-*), artifacts
+      # (aibrix-quick-start-<run_id>) and the test working dir
+      # (workflows/tests/aibrix).
+      project: aibrix
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # 2 h budget. Cold path is vLLM / vllm-ascend wheels plus a ~1 GB
+      # Hugging Face snapshot of Qwen2.5-0.5B-Instruct, then Envoy +
+      # gateway + one chat completion. Do not add a container bind-mount
+      # for /root/.cache: the runner NFS already persists that tree.
+      timeout_minutes: 120
+      upstream_repo: vllm-project/aibrix
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/aibrix/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/aibrix/quick_start.md
+      # cwd is the repo root inside the `workflows` checkout (matches
+      # engine template's `working-directory: workflows`); env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep lives in the test subclass's
+      # prepare_environment hook.
+      test_command: python -m unittest tests.aibrix.test_quick_start_ascend -v 2>&1

--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,10 @@ language = 'zh_CN'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
-                    '.github', 'tests']
+                    '.github', 'tests',
+                    # Included into sources/aibrix/index.rst; excluding
+                    # the file itself avoids a nested sidebar「快速开始」.
+                    'sources/aibrix/quick_start.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -243,6 +243,13 @@
    <h2 class="scene-header">🚀 高性能推理与服务</h2>
    <div class="grid-container">
 
+      <!-- aibrix -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/vllm-ascend.png')"></div><h3 class="card-title">aibrix</h3></div>
+         <p class="card-desc">可组合的 GenAI 推理基础设施，支持在昇腾上用 local mode 转发 OpenAI 兼容请求。</p>
+         <div class="card-footer"><a href="https://github.com/vllm-project/aibrix">官方链接</a><span class="split">|</span><a href="https://aibrix.readthedocs.io/latest/">文档中心</a><span class="split">|</span><a href="sources/aibrix/index.html">快速上手</a></div>
+      </div>
+
       <!-- llama.cpp -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/llama_cpp.png')"></div><h3 class="card-title">llama.cpp</h3></div>
@@ -425,6 +432,7 @@
    :hidden:
    :caption: 🚀 推理与服务
 
+   sources/aibrix/index.rst
    sources/llama_cpp/index.rst
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst

--- a/sources/aibrix/index.rst
+++ b/sources/aibrix/index.rst
@@ -1,0 +1,2 @@
+.. include:: quick_start.md
+   :parser: myst_parser.sphinx_

--- a/sources/aibrix/quick_start.md
+++ b/sources/aibrix/quick_start.md
@@ -1,0 +1,486 @@
+# aibrix
+
+在单卡昇腾上安装 vLLM-Ascend，拉起 [Qwen2.5-0.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct) 的 OpenAI 兼容服务，再经 AIBrix local mode 转发一次 chat completion。
+
+## 前置条件
+
+### 硬件
+
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。
+
+### 软件
+
+| 类别 | 要求 |
+| --- | --- |
+| CANN | toolkit + 驱动固件已安装，并可 `source set_env.sh` |
+| Python | 3.12 |
+| Go | 1.22.6，见下文安装 |
+| Envoy | 1.39.0 aarch64，见下文安装 |
+| vLLM-Ascend | `vllm` / `vllm-ascend` 均为 `0.23.0`，见下文安装 |
+| 模型 | [Qwen/Qwen2.5-0.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct) |
+
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。推荐配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+## 1. 加载 CANN 环境
+
+常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。后面的 vLLM 安装还依赖 ATB。
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/latest/atb/set_env.sh
+export PATH=/usr/local/sbin:/usr/sbin:$PATH
+```
+
+## 2. 检查环境是否就绪
+
+### 2.1 确认 NPU 在线
+
+```shell
+npu-smi info
+```
+
+:::{note}
+如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
+:::
+
+### 2.2 确认工具可用
+
+下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
+
+```shell #test id="check-tools"
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi >/dev/null
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-tools"
+Python 3.12...
+```
+
+## 3. 安装系统工具
+
+`run-local.sh` 用 `ss` 探测网关端口，没有就装 `iproute2`。
+
+<!--
+```shell #test-setup
+if getent hosts cache-service.nginx-pypi-cache.svc.cluster.local >/dev/null 2>&1 \
+    && [ -f /etc/apt/sources.list ]; then
+  sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+fi
+```
+-->
+
+```shell #test id="install-system-prereqs"
+if ! command -v ss >/dev/null 2>&1; then
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y iproute2
+fi
+ss --version
+```
+
+输出结果如下：
+
+```shell #test-result id="install-system-prereqs"
+...ss utility, iproute2-...
+```
+
+## 4. 安装 Go 1.22.6
+
+把官方 linux-arm64 包解压到 `.aibrix-quick-start/toolchain/go`。
+
+<!--
+```shell #test-setup
+set -euo pipefail
+ci='/root/.cache/huggingface/aibrix'
+cached="$ci/go1.22.6.linux-arm64.tar.gz"
+sum='c15fa895341b8eaf7f219fada25c36a610eb042985dc1a912410c1c90098eaf2'
+if [ -f "$cached" ]; then
+  if echo "$sum  $cached" | sha256sum -c >/dev/null 2>&1; then
+    mkdir -p .aibrix-quick-start/toolchain
+    cp -a "$cached" .aibrix-quick-start/go.tar.gz
+    tar -C .aibrix-quick-start/toolchain -xzf .aibrix-quick-start/go.tar.gz
+  else
+    rm -f "$cached"
+  fi
+fi
+```
+-->
+
+```shell #test id="install-go"
+mkdir -p .aibrix-quick-start/toolchain
+if [ ! -x .aibrix-quick-start/toolchain/go/bin/go ]; then
+  curl -fL --retry 3 --retry-delay 5 --connect-timeout 30 \
+    -o .aibrix-quick-start/go.tar.gz \
+    https://dl.google.com/go/go1.22.6.linux-arm64.tar.gz
+  tar -C .aibrix-quick-start/toolchain -xzf .aibrix-quick-start/go.tar.gz
+fi
+.aibrix-quick-start/toolchain/go/bin/go version
+```
+
+<!--
+```shell #test-setup
+set -euo pipefail
+ci='/root/.cache/huggingface/aibrix'
+src='.aibrix-quick-start/go.tar.gz'
+sum='c15fa895341b8eaf7f219fada25c36a610eb042985dc1a912410c1c90098eaf2'
+if [ -f "$src" ] && [ ! -f "$ci/go1.22.6.linux-arm64.tar.gz" ]; then
+  echo "$sum  $src" | sha256sum -c
+  mkdir -p "$ci"
+  cp -a "$src" "$ci/go1.22.6.linux-arm64.tar.gz.part"
+  mv "$ci/go1.22.6.linux-arm64.tar.gz.part" "$ci/go1.22.6.linux-arm64.tar.gz"
+fi
+```
+-->
+
+输出结果如下：
+
+```shell #test-result id="install-go"
+go version go1.22.6 linux/arm64
+```
+
+## 5. 安装 Envoy 1.39.0
+
+local mode 经 Envoy 监听 `:10080`。从 GitHub Release 下载官方 aarch64 包。
+
+<!--
+```shell #test-setup
+set -euo pipefail
+ci='/root/.cache/huggingface/aibrix'
+cached="$ci/envoy-1.39.0-linux-aarch_64"
+sum='ee53a4f5375566f15944dc9cb03afb1fc228df38f61737c677f139213215afcf'
+if [ -f "$cached" ]; then
+  if echo "$sum  $cached" | sha256sum -c >/dev/null 2>&1; then
+    mkdir -p .aibrix-quick-start/bin
+    cp -a "$cached" .aibrix-quick-start/bin/envoy
+    chmod 0755 .aibrix-quick-start/bin/envoy
+  else
+    rm -f "$cached"
+  fi
+fi
+```
+-->
+
+```shell #test id="install-envoy"
+mkdir -p .aibrix-quick-start/bin
+if [ ! -x .aibrix-quick-start/bin/envoy ]; then
+  curl -fL --retry 3 --retry-delay 5 --connect-timeout 30 \
+    -o .aibrix-quick-start/bin/envoy.part \
+    https://github.com/envoyproxy/envoy/releases/download/v1.39.0/envoy-1.39.0-linux-aarch_64
+  mv .aibrix-quick-start/bin/envoy.part .aibrix-quick-start/bin/envoy
+  chmod +x .aibrix-quick-start/bin/envoy
+fi
+.aibrix-quick-start/bin/envoy --version
+```
+
+<!--
+```shell #test-setup
+set -euo pipefail
+ci='/root/.cache/huggingface/aibrix'
+src='.aibrix-quick-start/bin/envoy'
+sum='ee53a4f5375566f15944dc9cb03afb1fc228df38f61737c677f139213215afcf'
+echo "$sum  $src" | sha256sum -c
+if [ ! -f "$ci/envoy-1.39.0-linux-aarch_64" ]; then
+  mkdir -p "$ci"
+  cp -a "$src" "$ci/envoy-1.39.0-linux-aarch_64.part"
+  mv "$ci/envoy-1.39.0-linux-aarch_64.part" "$ci/envoy-1.39.0-linux-aarch_64"
+fi
+```
+-->
+
+输出结果如下：
+
+```shell #test-result id="install-envoy"
+...1.39.0...
+```
+
+## 6. 克隆 AIBrix 并编译网关
+
+克隆 release tag（`<ref>` 可改为例如 `v0.7.0`）。只用下面的 `go build`，不要跑 `make build-gateway-plugins-nozmq`。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+```shell #test id="clone-aibrix" load="upstream_ref>>ref"
+if [ ! -d .aibrix-quick-start/aibrix/.git ]; then
+  rm -rf .aibrix-quick-start/aibrix
+  for _ in 1 2 3; do
+    GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
+      git clone --depth 1 --branch <ref> https://github.com/vllm-project/aibrix.git .aibrix-quick-start/aibrix && break
+    rm -rf .aibrix-quick-start/aibrix
+    sleep 5
+  done
+fi
+git -C .aibrix-quick-start/aibrix describe --tags --exact-match
+```
+
+输出结果如下：
+
+```shell #test-result id="clone-aibrix" load="upstream_ref>>ref"
+<ref>
+```
+
+`GOPATH` / `GOCACHE` 使用工作目录。
+
+```shell #test id="build-gateway"
+export GOPATH="$PWD/.aibrix-quick-start/gopath"
+export GOCACHE="$PWD/.aibrix-quick-start/gocache"
+mkdir -p "$GOPATH" "$GOCACHE"
+cd .aibrix-quick-start/aibrix
+CGO_ENABLED=0 "$PWD/../toolchain/go/bin/go" build -tags=nozmq -o bin/gateway-plugins cmd/plugins/main.go
+"$PWD/../toolchain/go/bin/go" version -m bin/gateway-plugins
+```
+
+输出结果如下：
+
+```shell #test-result id="build-gateway"
+bin/gateway-plugins: go1.22.6
+...
+```
+
+<!--
+```shell #test-setup
+set -euo pipefail
+plugin="$PWD/.aibrix-quick-start/aibrix/bin/gateway-plugins"
+if python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 6060))' >/dev/null 2>&1; then
+  echo pprof_port_free
+  exit 0
+fi
+test -x "$plugin"
+real="$plugin.real"
+mv "$plugin" "$real"
+cat > "$plugin" <<'WRAP'
+#!/usr/bin/env bash
+set -euo pipefail
+hosts=$(mktemp)
+{
+  printf '%s\t%s\n' '127.0.0.2' 'localhost'
+  printf '%s\t%s\n' '127.0.0.1' "$(hostname)"
+} > "$hosts"
+exec unshare --user --map-root-user --mount --fork -- \
+  bash -c 'mount --bind "$1" /etc/hosts; shift; exec "$@"' \
+  bash "$hosts" \
+  REAL_PLACEHOLDER "$@"
+WRAP
+sed -i "s|REAL_PLACEHOLDER|${real}|g" "$plugin"
+chmod +x "$plugin"
+echo pprof_port_wrapped
+```
+-->
+
+## 7. 安装 vLLM-Ascend
+
+分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton，第一次推理报错。
+
+```shell #test id="install-vllm"
+python -m pip install --retries 3 vllm==0.23.0
+python -m pip install \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  vllm-ascend==0.23.0
+python -m pip install --force-reinstall --no-deps \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  triton-ascend==3.2.2
+python -c "import importlib.metadata as m
+for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
+    print(n, m.version(n))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-vllm"
+...
+torch 2.10.0...
+torch-npu 2.10.0.post4
+vllm 0.23.0...
+vllm-ascend 0.23.0
+```
+
+## 8. 启动 vLLM-Ascend 后端
+
+后台启动服务、日志落盘，并轮询 `/health` 直到就绪。`--max-model-len` / `--max-num-seqs` / `--gpu-memory-utilization` 压到单卡演示规模；`--served-model-name` 须与下一节网关配置一致。
+
+```shell #test id="start-backend"
+export PYTHONUNBUFFERED=1
+mkdir -p .aibrix-quick-start
+: > .aibrix-quick-start/vllm.log
+setsid bash -c '
+  echo $$ > .aibrix-quick-start/vllm.pid
+  exec vllm serve Qwen/Qwen2.5-0.5B-Instruct \
+    --served-model-name Qwen/Qwen2.5-0.5B-Instruct \
+    --host 127.0.0.1 \
+    --port 8000 \
+    --max-model-len 2048 \
+    --max-num-seqs 4 \
+    --gpu-memory-utilization 0.2
+' </dev/null >> .aibrix-quick-start/vllm.log 2>&1 &
+for i in $(seq 1 180); do
+  pid=$(cat .aibrix-quick-start/vllm.pid 2>/dev/null || true)
+  if [ -n "${pid}" ] && ! kill -0 "${pid}" 2>/dev/null; then
+    echo 'vLLM exited before /health succeeded. Full log:'
+    cat .aibrix-quick-start/vllm.log
+    exit 1
+  fi
+  if [ -n "${pid}" ] \
+      && curl -sf --connect-timeout 2 -- 'http://127.0.0.1:8000/health' >/dev/null \
+      && ss -ltnp 'sport = :8000' | grep -q "pid=${pid},"; then
+    echo 'vLLM /health OK'
+    exit 0
+  fi
+  sleep 2
+done
+echo 'timed out waiting for http://127.0.0.1:8000/health. Full log:'
+cat .aibrix-quick-start/vllm.log
+exit 1
+```
+
+输出结果如下：
+
+```shell #test-result id="start-backend"
+...
+vLLM /health OK
+```
+
+日志里应有 `backend=hccl`，说明这一次推理走了昇腾集合通信。
+
+```shell #test id="backend-on-npu"
+grep -F 'backend=hccl' .aibrix-quick-start/vllm.log
+```
+
+输出结果如下：
+
+```shell #test-result id="backend-on-npu"
+...backend=hccl...
+```
+
+## 9. 配置网关并启动 local mode
+
+模型名与 `--served-model-name` 一致；endpoint 用 `127.0.0.1:8000`。
+
+保存为 `.aibrix-quick-start/endpoints.yaml`：
+
+```yaml
+models:
+  - name: "Qwen/Qwen2.5-0.5B-Instruct"
+    engine: "vllm"
+    endpoints:
+      - "127.0.0.1:8000"
+```
+
+<!--
+```shell #test-setup
+cat > .aibrix-quick-start/endpoints.yaml <<'YAML'
+models:
+  - name: "Qwen/Qwen2.5-0.5B-Instruct"
+    engine: "vllm"
+    endpoints:
+      - "127.0.0.1:8000"
+YAML
+```
+-->
+
+`run-local.sh` 从 PATH 找 `envoy`；`endpoints.yaml` 须绝对路径。
+
+```shell #test id="start-gateway"
+export PATH="$PWD/.aibrix-quick-start/bin:$PATH"
+bash .aibrix-quick-start/aibrix/deployment/local/run-local.sh \
+  -e "$PWD/.aibrix-quick-start/endpoints.yaml"
+```
+
+输出结果如下：
+
+```shell #test-result id="start-gateway"
+...
+AIBrix gateway is running!
+...
+```
+
+## 10. 发一次推理
+
+经 `:10080` 发 chat completion。生成内容非确定性，只核对模型名与回复非空。
+
+保存为 `.aibrix-quick-start/chat_completion.py`：
+
+```python
+import json
+import urllib.request
+
+payload = {
+    'model': 'Qwen/Qwen2.5-0.5B-Instruct',
+    'messages': [{'role': 'user', 'content': 'Say hi in one sentence.'}],
+    'max_tokens': 32,
+    'temperature': 0,
+}
+request = urllib.request.Request(
+    'http://127.0.0.1:10080/v1/chat/completions',
+    data=json.dumps(payload).encode(),
+    headers={'Content-Type': 'application/json'},
+    method='POST',
+)
+with urllib.request.urlopen(request, timeout=120) as response:
+    body = json.load(response)
+content = (body['choices'][0]['message']['content'] or '').strip()
+print('model', body['model'])
+print('content_nonempty', 'true' if content else 'false')
+print('completion_tokens', body['usage']['completion_tokens'])
+```
+
+<!--
+```shell #test-setup
+cat > .aibrix-quick-start/chat_completion.py <<'PY'
+import json
+import urllib.request
+
+payload = {
+    'model': 'Qwen/Qwen2.5-0.5B-Instruct',
+    'messages': [{'role': 'user', 'content': 'Say hi in one sentence.'}],
+    'max_tokens': 32,
+    'temperature': 0,
+}
+request = urllib.request.Request(
+    'http://127.0.0.1:10080/v1/chat/completions',
+    data=json.dumps(payload).encode(),
+    headers={'Content-Type': 'application/json'},
+    method='POST',
+)
+with urllib.request.urlopen(request, timeout=120) as response:
+    body = json.load(response)
+content = (body['choices'][0]['message']['content'] or '').strip()
+print('model', body['model'])
+print('content_nonempty', 'true' if content else 'false')
+print('completion_tokens', body['usage']['completion_tokens'])
+PY
+```
+-->
+
+```shell #test id="infer"
+python .aibrix-quick-start/chat_completion.py
+```
+
+输出结果如下：
+
+```shell #test-result id="infer"
+model Qwen/Qwen2.5-0.5B-Instruct
+content_nonempty true
+completion_tokens ...
+```
+
+## 11. 停掉本机进程
+
+先停网关，再按 PID 停 vLLM。
+
+```shell #test-setup
+if [ -x .aibrix-quick-start/aibrix/deployment/local/stop-local.sh ]; then
+  bash .aibrix-quick-start/aibrix/deployment/local/stop-local.sh || true
+fi
+if [ -f .aibrix-quick-start/vllm.pid ]; then
+  pid=$(cat .aibrix-quick-start/vllm.pid)
+  if [ -n "${pid}" ]; then
+    kill "${pid}" 2>/dev/null || true
+  fi
+fi
+```

--- a/sources/aibrix/quick_start.md
+++ b/sources/aibrix/quick_start.md
@@ -39,9 +39,7 @@ export PATH=/usr/local/sbin:/usr/sbin:$PATH
 npu-smi info
 ```
 
-:::{note}
 如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
-:::
 
 ### 2.2 确认工具可用
 
@@ -195,7 +193,7 @@ fi
 ...1.39.0...
 ```
 
-## 6. 克隆 AIBrix 并编译网关
+## 6. 获取 AIBrix 源码并编译网关
 
 克隆 release tag（`<ref>` 可改为例如 `v0.7.0`）。只用下面的 `go build`，不要跑 `make build-gateway-plugins-nozmq`。
 
@@ -276,6 +274,27 @@ echo pprof_port_wrapped
 
 分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton，第一次推理报错。
 
+保存为 `.aibrix-quick-start/print_pkg_versions.py`：
+
+```python
+import importlib.metadata as m
+
+for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
+    print(n, m.version(n))
+```
+
+<!--
+```shell #test-setup
+mkdir -p .aibrix-quick-start
+cat > .aibrix-quick-start/print_pkg_versions.py <<'PY'
+import importlib.metadata as m
+
+for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
+    print(n, m.version(n))
+PY
+```
+-->
+
 ```shell #test id="install-vllm"
 python -m pip install --retries 3 vllm==0.23.0
 python -m pip install \
@@ -285,9 +304,7 @@ python -m pip install \
 python -m pip install --force-reinstall --no-deps \
   --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
   triton-ascend==3.2.2
-python -c "import importlib.metadata as m
-for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
-    print(n, m.version(n))"
+python .aibrix-quick-start/print_pkg_versions.py
 ```
 
 输出结果如下：

--- a/sources/aibrix/quick_start.md
+++ b/sources/aibrix/quick_start.md
@@ -341,7 +341,6 @@ exit 1
 输出结果如下：
 
 ```shell #test-result id="start-backend"
-...
 vLLM /health OK
 ```
 

--- a/tests/aibrix/__init__.py
+++ b/tests/aibrix/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent ``__init__.py``
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/aibrix/__init__.py -> parents[0]=tests/aibrix,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/aibrix/test_quick_start_ascend.py
+++ b/tests/aibrix/test_quick_start_ascend.py
@@ -1,0 +1,185 @@
+"""Quick-start test: doc under test is ``sources/aibrix/quick_start.md``.
+
+Run: ``python -m unittest tests.aibrix.test_quick_start_ascend -v 2>&1``
+
+Env (injected by the engine ``quick-start-template.yml``, triggered by
+``aibrix-quick-start.yml``): ``MONITORED_DOC_URL``, ``UPSTREAM_REF``,
+``NPU_READY=true`` (otherwise the class is skipped).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import time
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    ensure_safetensors,
+    purge_huggingface_corrupt,
+    report_huggingface_state,
+    resolve_huggingface_cache,
+)
+
+_WORK_DIR = Path('.aibrix-quick-start')
+_CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+_ATB_SET_ENV = '/usr/local/Ascend/nnal/atb/latest/atb/set_env.sh'
+
+
+def _is_truthy(value: str | None) -> bool:
+    """``'true'`` -> True (case-insensitive); anything else (including unset) -> False."""
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    """Return True when ``NPU_READY=true`` is set, releasing the skip."""
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+def _read_pids(path: Path) -> list[int]:
+    try:
+        text = path.read_text(encoding='utf-8')
+    except OSError:
+        return []
+    pids: list[int] = []
+    for token in text.split():
+        try:
+            pid = int(token)
+        except ValueError:
+            continue
+        if pid > 1:
+            pids.append(pid)
+    return pids
+
+
+def _stop_pid(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    for _ in range(30):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+
+
+def cleanup_aibrix_workdir(root: Path) -> None:
+    for pid in _read_pids(root / 'vllm.pid'):
+        _stop_pid(pid)
+    local_pids = root / 'aibrix' / 'deployment' / 'local' / '.pids'
+    for pid in _read_pids(local_pids):
+        _stop_pid(pid)
+    if root.exists():
+        shutil.rmtree(root, ignore_errors=True)
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    """End-to-end test: fetch doc -> validate contract -> run ``#test-setup``
+    / ``#test`` in order -> compare against ``#test-result``."""
+
+    DEFAULT_COMMAND_TIMEOUT = 3600
+    USER_AGENT = 'ascend-docs/quick-start'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'ERR99999',
+        'Invalid device ID',
+        'Address already in use',
+        'libatb.so',
+        'no healthy upstream',
+    )
+
+    _MODEL_ID = 'Qwen/Qwen2.5-0.5B-Instruct'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN / ATB once so later ``bash -c`` blocks inherit them.
+
+        Class-level setup: run once per test class, triggered by
+        ``setUpClass``. Each labeled fence is a new subprocess, so a
+        ``source set_env.sh`` block in the document does not persist.
+
+        Merge is overwrite, not ``setdefault``: the container image may
+        already ship ``LD_LIBRARY_PATH``, which would otherwise hide the
+        CANN increment from ``set_env.sh``.
+        """
+        venv_prefix = ''
+        virtual_env = os.environ.get('VIRTUAL_ENV')
+        if virtual_env:
+            venv_prefix = str(Path(virtual_env) / 'bin')
+
+        missing = [p for p in (_CANN_SET_ENV, _ATB_SET_ENV) if not os.path.isfile(p)]
+        if missing:
+            raise RuntimeError(
+                'required Ascend env scripts missing: ' + ', '.join(missing)
+            )
+        sourced = ' && '.join(
+            f'source {shlex.quote(script)} >/dev/null 2>&1'
+            for script in (_CANN_SET_ENV, _ATB_SET_ENV)
+        )
+        merged = subprocess.run(
+            ['bash', '-c', f'{sourced}; env'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            os.environ[key] = value
+        extras = []
+        for extra in ('/usr/local/sbin', '/usr/local/bin', '/usr/sbin'):
+            parts = os.environ.get('PATH', '').split(':')
+            if extra not in parts:
+                extras.append(extra)
+        if extras:
+            os.environ['PATH'] = os.environ.get('PATH', '') + ':' + ':'.join(extras)
+        if venv_prefix:
+            current = os.environ.get('PATH', '')
+            if not current.startswith(venv_prefix + ':'):
+                os.environ['PATH'] = f'{venv_prefix}:{current}'
+        print('setup: sourced CANN and ATB env')
+
+        ensure_safetensors()
+        report_huggingface_state(cls._MODEL_ID)
+        purge_huggingface_corrupt(resolve_huggingface_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing when
+        ``NPU_READY`` is unset.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    def post_process(self) -> None:
+        cleanup_aibrix_workdir(_WORK_DIR)
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Run the full pre_process -> parse -> execute -> post_process flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- 把 `vllm-project/aibrix` 昇腾 Quick Start 迁到 `sources/aibrix/`。装 vLLM 用统一三步 pip（`vllm` / `vllm-ascend` 0.23.0，最后强制重装 `triton-ascend`），模型走 Hugging Face `Qwen/Qwen2.5-0.5B-Instruct`，工作负载预期含 `backend=hccl`。
- 接入共享引擎：薄触发器 `aibrix-quick-start.yml`（不传 `container_options` / `--volume`）+ `tests/aibrix` 子类；首页推理区增加卡片和 toctree。

## Test plan
- [x] 本机解析块数 > 0、可见正文泄漏检查、`actionlint`、测试文件 `py_compile`
- [ ] 合入后在香港 A2 上 `workflow_dispatch` 跑冷/热缓存；fork PR 的 `doc_url` 会 404，属预期
- [ ] 工作负载日志出现 `backend=hccl`，经 `:10080` 的 chat completion 返回非空回复