### PR TITLE
docs(flash-linear-attention): migrate Ascend quick start guard

### DIFF
--- a/.github/workflows/flash-linear-attention-quick-start.yml
+++ b/.github/workflows/flash-linear-attention-quick-start.yml
@@ -1,0 +1,34 @@
+# flash-linear-attention Ascend Quick Start guard.
+name: flash-linear-attention-quick-start
+
+concurrency:
+  group: ${{ github.event_name == 'schedule' && 'flash-linear-attention-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  cancel-in-progress: false
+
+on:
+  schedule:
+    - cron: '25 */6 * * *'
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/flash-linear-attention/**'
+      - 'tests/flash_linear_attention/**'
+      - '.github/workflows/flash-linear-attention-quick-start.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  flash-linear-attention-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      project: flash-linear-attention
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.0.0-910b-ubuntu22.04-py3.11
+      container_options: '--shm-size=16g'
+      timeout_minutes: 120
+      upstream_repo: fla-org/flash-linear-attention
+      doc_url: 'https://api.github.com/repos/Ascend/docs/contents/sources/flash-linear-attention/quick_start.md?ref={0}'
+      doc_path: https://github.com/Ascend/docs/blob/${{ github.sha }}/sources/flash-linear-attention/quick_start.md
+      test_command: python -m unittest tests.flash_linear_attention.test_quick_start_ascend -v 2>&1

--- a/index.rst
+++ b/index.rst
@@ -311,6 +311,13 @@
          <div class="card-footer"><a href="https://github.com/linkedin/Liger-Kernel">官方链接</a><span class="split">|</span><a href="sources/liger-kernel/install.html">安装指南</a><span class="split">|</span><a href="sources/liger-kernel/quick_start.html">快速上手</a></div>
       </div>
 
+      <!-- flash-linear-attention -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/pytorch.png')"></div><h3 class="card-title">flash-linear-attention</h3></div>
+         <p class="card-desc">高效线性注意力算子库，支持通过 Triton-Ascend 在昇腾 NPU 上训练。</p>
+         <div class="card-footer"><a href="https://github.com/fla-org/flash-linear-attention">官方链接</a><span class="split">|</span><a href="https://github.com/fla-org/flash-linear-attention/blob/main/INSTALL.md#ascend-npu">安装指南</a><span class="split">|</span><a href="sources/flash-linear-attention/quick_start.html">快速上手</a></div>
+      </div>
+
    </div>
 
    <h2 class="scene-header">🎨 多模态应用、评测与工具</h2>
@@ -440,6 +447,7 @@
 
    sources/triton-ascend/index.rst
    sources/liger-kernel/index.rst
+   sources/flash-linear-attention/index.md
 
 .. toctree::
    :maxdepth: 1
@@ -455,4 +463,3 @@
    sources/timm/index.rst
    sources/wenet/index.rst
    sources/whisper_cpp/index.rst
-

--- a/sources/flash-linear-attention/index.md
+++ b/sources/flash-linear-attention/index.md
@@ -1,0 +1,6 @@
+# flash-linear-attention
+
+flash-linear-attention 通用文档由上游社区维护。本页收录经过持续验证的 Ascend NPU 快速上手。
+
+```{include} quick_start.md
+```

--- a/sources/flash-linear-attention/quick_start.md
+++ b/sources/flash-linear-attention/quick_start.md
@@ -1,0 +1,178 @@
+# 快速开始
+
+在单张昇腾 NPU 上安装 flash-linear-attention，验证 Triton-Ascend backend，并完成一次真实的前向与反向计算。本文基于上游
+[Ascend NPU 安装说明](https://github.com/fla-org/flash-linear-attention/blob/main/INSTALL.md#ascend-npu)
+和 `GatedDeltaNet` 公共 API 编写。
+
+## 前置条件
+
+### 硬件
+
+- Atlas 800T / 900 A2 训练系列；
+- 至少一张可用的 Ascend 910B NPU；
+- 物理机或容器已正确配置驱动和设备。
+
+### 基础软件
+
+在运行本文档之前，机器上需要已经安装并可用：
+
+- Linux aarch64 操作系统；
+- 可用的 Python 环境；
+- 可用的 CANN toolkit 和驱动；
+- `npu-smi` 能正常显示 NPU 设备。
+
+CANN 安装可参考[快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html)。Torch、Torch-NPU、torchvision 和 Triton-Ascend 由目标 release 的 `[npu]` extra 安装。
+
+### 本文档示例使用的版本
+
+当前 Quick Start 模板看护上游最新正式 release。配套环境为：
+
+| 组件 | 版本 |
+| --- | --- |
+| 操作系统 | Ubuntu 22.04，Linux aarch64 |
+| Python | 3.11 |
+| CANN | 9.0.0 |
+| flash-linear-attention | 工作流注入的最新 release 源码 |
+| Torch / Torch-NPU / Triton-Ascend | 由目标 release 的 `[npu]` extra 决定 |
+| NPU | Ascend 910B × 1 |
+
+```{admonition} Note
+:class: note
+上游 `main` 的安装栈可能领先于最新 release。本文始终 checkout 工作流注入的 release ref，避免把新版本依赖与旧版本源码混用。
+```
+
+### 检查前置是否满足
+
+```shell #test id="check-cann"
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+export PATH=/usr/local/sbin:$PATH
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi >/dev/null
+printf 'CANN ready\n'
+```
+
+```shell #test-result id="check-cann"
+CANN ready
+```
+
+## 安装 flash-linear-attention
+
+安装过程与上游 A2 CI 保持一致：先安装 Triton-Ascend 的构建和运行依赖，再从目标源码的 `[npu]` extra 安装匹配的 Torch、Torch-NPU、torchvision 与 Triton-Ascend。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+```shell #test id="install-fla" load="upstream_ref>>UPSTREAM_REF"
+test ! -e flash-linear-attention
+git clone https://github.com/fla-org/flash-linear-attention.git
+cd flash-linear-attention
+git checkout <UPSTREAM_REF>
+python -m pip install -q -U pip setuptools wheel
+python -m pip install -q pybind11 cmake attrs sympy pyyaml scipy decorator einops
+python -m pip install -q ".[npu]" \
+  --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple
+python -c "import fla; print('fla', fla.__version__)"
+```
+
+```shell #test-result id="install-fla" fuzzy="xxx"
+fla xxx
+```
+
+## 验证 Ascend NPU backend
+
+flash-linear-attention 通过 Triton runtime 识别 `npu` backend，并将 `fla.utils.IS_NPU` 设置为 `True`。
+
+```shell #test id="check-npu"
+python - <<'PY'
+import torch
+import torch_npu
+import triton
+
+from fla.utils import IS_NPU, device_platform
+
+assert torch.npu.is_available()
+assert IS_NPU
+assert device_platform == "npu"
+
+print("torch", torch.__version__)
+print("torch_npu", torch_npu.__version__)
+print("triton", triton.__version__)
+print("device_platform", device_platform)
+print("npu_available", torch.npu.is_available())
+PY
+```
+
+```shell #test-result id="check-npu" fuzzy="xxx"
+torch xxx
+torch_npu xxx
+triton xxx
+device_platform npu
+npu_available True
+```
+
+## 使用样例
+
+### GatedDeltaNet 前向与反向
+
+下面的配置来自上游 `GatedDeltaNet` 测试所使用的小型 shape。该链路会实际执行线性层、Causal Conv1D、Gated Delta Rule 和门控 RMSNorm，并验证输出与输入梯度均为有限值。
+
+```shell #test id="gdn-forward-backward"
+python - <<'PY'
+import torch
+import torch_npu
+
+from fla.layers import GatedDeltaNet
+from fla.utils import IS_NPU, device_platform
+
+assert IS_NPU
+assert device_platform == "npu"
+torch.manual_seed(42)
+
+layer = GatedDeltaNet(
+    hidden_size=512,
+    head_dim=64,
+    num_heads=6,
+    expand_v=2,
+    mode="chunk",
+).to(device="npu", dtype=torch.bfloat16).train()
+
+x = torch.randn(
+    1,
+    128,
+    512,
+    device="npu",
+    dtype=torch.bfloat16,
+    requires_grad=True,
+)
+y = layer(x)[0]
+loss = y.float().square().mean()
+loss.backward()
+torch.npu.synchronize()
+
+assert y.shape == (1, 128, 512)
+assert torch.isfinite(y).all()
+assert x.grad is not None
+assert torch.isfinite(x.grad).all()
+
+print("device", y.device.type)
+print("output_shape", tuple(y.shape))
+print("forward_finite", torch.isfinite(y).all().item())
+print("backward_finite", torch.isfinite(x.grad).all().item())
+PY
+```
+
+```shell #test-result id="gdn-forward-backward"
+device npu
+output_shape (1, 128, 512)
+forward_finite True
+backward_finite True
+```
+
+## 说明
+
+- 该 Quick Start 验证单卡真实前向与反向，不是多卡分布式训练；
+- `IS_NPU=True` 证明 FLA 识别到了 Triton-Ascend backend；
+- 输出和梯度位于 NPU 且均为有限值，任何 CPU 静默回退、kernel 编译失败或数值异常都会使测试失败。

--- a/tests/flash_linear_attention/__init__.py
+++ b/tests/flash_linear_attention/__init__.py
@@ -1,0 +1,12 @@
+"""flash-linear-attention Quick Start tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / "tests"
+for _path in (_TESTS_ROOT, _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))

--- a/tests/flash_linear_attention/test_project_contract.py
+++ b/tests/flash_linear_attention/test_project_contract.py
@@ -1,0 +1,49 @@
+"""Static contract for the migrated flash-linear-attention Quick Start."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "sources" / "flash-linear-attention" / "quick_start.md"
+WORKFLOW = ROOT / ".github" / "workflows" / "flash-linear-attention-quick-start.yml"
+
+
+class TestProjectContract(unittest.TestCase):
+    def test_document_keeps_the_validated_npu_path(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        test_ids = set(re.findall(r'#test id="([^"]+)"', text))
+        result_ids = set(re.findall(r'#test-result id="([^"]+)"', text))
+
+        self.assertEqual(
+            test_ids,
+            {"check-cann", "install-fla", "check-npu", "gdn-forward-backward"},
+        )
+        self.assertEqual(result_ids, test_ids)
+        self.assertIn('python -m pip install -q ".[npu]"', text)
+        self.assertIn("loss.backward()", text)
+        self.assertIn("torch.npu.synchronize()", text)
+
+    def test_workflow_preserves_the_validated_environment(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("uses: ./.github/workflows/quick-start-template.yml", text)
+        self.assertIn("project: flash-linear-attention", text)
+        self.assertIn("linux-aarch64-a2-1", text)
+        self.assertIn("cann:9.0.0-910b-ubuntu22.04-py3.11", text)
+        self.assertIn("container_options: '--shm-size=16g'", text)
+        self.assertIn("upstream_repo: fla-org/flash-linear-attention", text)
+        self.assertIn("tests.flash_linear_attention.test_quick_start_ascend", text)
+
+    def test_project_is_reachable_from_the_site_navigation(self) -> None:
+        index = (ROOT / "index.rst").read_text(encoding="utf-8")
+
+        self.assertIn("sources/flash-linear-attention/index.md", index)
+        self.assertIn("sources/flash-linear-attention/quick_start.html", index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/flash_linear_attention/test_quick_start_ascend.py
+++ b/tests/flash_linear_attention/test_quick_start_ascend.py
@@ -1,0 +1,71 @@
+"""End-to-end test for the flash-linear-attention Ascend Quick Start."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+
+
+def _e2e_enabled() -> bool:
+    return os.environ.get("NPU_READY", "").strip().lower() == "true"
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    DEFAULT_COMMAND_TIMEOUT = 3600
+    USER_AGENT = "Ascend/docs/flash-linear-attention-quick-start"
+    _CANN_SET_ENV = "/usr/local/Ascend/ascend-toolkit/set_env.sh"
+
+    def pre_process(self) -> str:
+        doc_path = (
+            Path(__file__).resolve().parents[2]
+            / "sources"
+            / "flash-linear-attention"
+            / "quick_start.md"
+        )
+        if not doc_path.is_file():
+            raise RuntimeError(f"Quick Start document not found: {doc_path}")
+        return doc_path.read_text(encoding="utf-8")
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        path_dirs = "/usr/local/sbin:/usr/local/bin"
+        current_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{path_dirs}:{current_path}"
+        os.environ["PYTHONNOUSERSITE"] = "1"
+        os.environ.setdefault("ASCEND_RT_VISIBLE_DEVICES", "0")
+
+        if not os.path.isfile(cls._CANN_SET_ENV):
+            raise RuntimeError(f"CANN environment script is missing: {cls._CANN_SET_ENV}")
+
+        merged = subprocess.run(
+            ["bash", "-c", f"source {cls._CANN_SET_ENV} >/dev/null 2>&1; env"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            os.environ[key] = value
+        print("setup: sourced CANN environment")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        "end-to-end requires an Ascend NPU runner; set NPU_READY=true",
+    )
+    def test_runs_doc(self) -> None:
+        self.run_template()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- migrate the validated flash-linear-attention Ascend NPU Quick Start into `sources/`
- add the project-local executable documentation test and thin reusable-workflow caller
- add the project to the operator-development homepage section and Sphinx navigation

## Validation

- `python -m unittest tests.flash_linear_attention.test_project_contract tests.flash_linear_attention.test_quick_start_ascend -v`
- parsed the Markdown contract with 5 executable commands and 4 expected-output blocks
- `actionlint .github/workflows/flash-linear-attention-quick-start.yml`
- Sphinx HTML build succeeds; the remaining PyTorch API warning predates this change

The guarded path retains the proven CANN 9.0 / Python 3.11 image, one-NPU runner, 16 GiB shared memory, latest-release checkout, and real GatedDeltaNet forward/backward smoke.