### PR TITLE
[feature] 迁移 FlagScale Quick Start 并接入看护

### DIFF
--- a/.github/workflows/flagscale-quick-start.yml
+++ b/.github/workflows/flagscale-quick-start.yml
@@ -1,0 +1,68 @@
+# flagscale quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+
+name: flagscale-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'flagscale-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Offset from peft's '30 */3 * * *' and llama_cpp's '45 */3 * * *'.
+    - cron: '20 */3 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/flagscale/**'
+      - 'tests/flagscale/**'
+
+permissions:
+  contents: read
+
+jobs:
+  flagscale-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-flagscale-*), artifacts
+      # (flagscale-quick-start-<run_id>) and the test working dir
+      # (workflows/tests/flagscale).
+      project: flagscale
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest. Two cards: the doc sets
+      # ASCEND_RT_VISIBLE_DEVICES=0,1 and tensor_parallel_size: 2.
+      test_runner: '["linux-aarch64-a2-2"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # Do not add a container bind-mount for /root/.cache: the runner
+      # NFS already persists that tree. Hub weights reuse the default
+      # Hugging Face cache. Cold path covers vLLM wheels, FlagGems
+      # source install, FL plugin, and a TP=2 0.5B generate.
+      timeout_minutes: 180
+      upstream_repo: flagos-ai/FlagScale
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/flagscale/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/flagscale/quick_start.md
+      # cwd is the repo root inside the `workflows` checkout (matches
+      # engine template's `working-directory: workflows`); env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep lives in the test subclass's
+      # prepare_environment hook.
+      test_command: python -m unittest tests.flagscale.test_quick_start_ascend -v 2>&1

--- a/.github/workflows/flagscale-quick-start.yml
+++ b/.github/workflows/flagscale-quick-start.yml
@@ -49,8 +49,8 @@ jobs:
       image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
       # Do not add a container bind-mount for /root/.cache: the runner
       # NFS already persists that tree. Hub weights reuse the default
-      # Hugging Face cache. Cold path covers vLLM wheels, FlagGems
-      # source install, FL plugin, and a TP=2 0.5B generate.
+      # Hugging Face cache. Cold path covers vLLM 0.23 and
+      # vllm-ascend 0.23 wheels plus a TP=2 0.5B generate.
       timeout_minutes: 180
       upstream_repo: flagos-ai/FlagScale
       # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the

--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,10 @@ language = 'zh_CN'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
-                    '.github', 'tests']
+                    '.github', 'tests',
+                    # Included into sources/flagscale/index.rst; excluding
+                    # the file itself avoids a nested sidebar「快速开始」.
+                    'sources/flagscale/quick_start.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -243,6 +243,13 @@
    <h2 class="scene-header">🚀 高性能推理与服务</h2>
    <div class="grid-container">
 
+      <!-- FlagScale -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/vllm-ascend.png')"></div><h3 class="card-title">FlagScale</h3></div>
+         <p class="card-desc">面向大模型训练、推理与服务的编排工具，昇腾路径通过 vLLM FL 插件做双卡离线推理。</p>
+         <div class="card-footer"><a href="https://github.com/flagos-ai/FlagScale">官方链接</a><span class="split">|</span><a href="https://github.com/flagos-ai/FlagScale">文档中心</a><span class="split">|</span><a href="sources/flagscale/index.html">快速上手</a></div>
+      </div>
+
       <!-- llama.cpp -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/llama_cpp.png')"></div><h3 class="card-title">llama.cpp</h3></div>
@@ -425,6 +432,7 @@
    :hidden:
    :caption: 🚀 推理与服务
 
+   sources/flagscale/index.rst
    sources/llama_cpp/index.rst
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst

--- a/sources/flagscale/index.rst
+++ b/sources/flagscale/index.rst
@@ -1,0 +1,2 @@
+.. include:: quick_start.md
+   :parser: myst_parser.sphinx_

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -93,7 +93,7 @@ vllm-ascend 0.23.0
 
 ## 4. 安装 FlagGems 与 vLLM FL 插件
 
-[FlagGems](https://github.com/flagos-ai/FlagGems) 提供给 FL 插件调度的算子。[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是 vLLM 的平台插件，注册名 `fl`。环境里同时有 `vllm-ascend` 与 `fl` 时，一次只允许激活一个平台插件，下文会设 `VLLM_PLUGINS=fl`。
+[FlagGems](https://github.com/flagos-ai/FlagGems) 提供算子，[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是注册名为 `fl` 的平台插件；与 `vllm-ascend` 同时存在时只激活一个，下文设 `VLLM_PLUGINS=fl`。社区 vLLM 0.24 只接受名为 `CUSTOM` 的第三方注意力后端，克隆后改这一处再安装。
 
 ```shell #test id="install-flag-stack"
 python -m pip install scikit-build-core pybind11 ninja cmake sqlalchemy==2.0.48
@@ -110,6 +110,12 @@ if [ ! -d vllm-plugin-FL/.git ]; then
     git clone --depth 1 --branch v0.3.0-rc1.post1 \
     https://github.com/flagos-ai/vllm-plugin-FL.git vllm-plugin-FL
 fi
+python - <<'PY'
+from pathlib import Path
+p = Path("vllm-plugin-FL/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py")
+text = p.read_text()
+p.write_text(text.replace('return "ASCEND_FL"', 'return "CUSTOM"', 1))
+PY
 python -m pip install --no-build-isolation --no-deps ./vllm-plugin-FL
 python -c "import flag_gems; from importlib.metadata import version; print('flag_gems', version('flag_gems')); print('vllm_fl', version('vllm-plugin-fl'))"
 ```
@@ -263,7 +269,6 @@ llm:
   max_model_len: 512
   max_num_batched_tokens: 512
   max_num_seqs: 1
-  attention_backend: "TORCH_SDPA"
   disable_custom_all_reduce: true
 
 generate:
@@ -328,7 +333,6 @@ llm:
   max_model_len: 512
   max_num_batched_tokens: 512
   max_num_seqs: 1
-  attention_backend: "TORCH_SDPA"
   disable_custom_all_reduce: true
 
 generate:

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -15,7 +15,8 @@ Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为�
 | CANN | toolkit + 驱动固件已安装，并可 `source set_env.sh` |
 | ATB | Ascend Transformer Boost。vLLM 子进程要加载 `libatb.so` |
 | Python | 3.12 |
-| vLLM-Ascend | `vllm` / `vllm-ascend` 均为 `0.23.0`，见下文安装 |
+| vLLM | `0.24.0`，与 vllm-plugin-FL 对齐，见下文安装 |
+| vLLM-Ascend | `0.23.0`，只用来提供 `torch` / `torch-npu` / `triton-ascend` |
 | FlagGems | `v5.3.4`，见下文安装 |
 | vllm-plugin-FL | `v0.3.0-rc1.post1`，注册名 `fl` |
 | FlagScale | 上游 Release tag，撰写时为 `v2.0.0` |
@@ -63,10 +64,10 @@ Python 3.12...
 
 ## 3. 安装 vLLM-Ascend
 
-分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。
+分三步安装，不要合成一次 `pip install`。先装社区 vLLM **0.24.0**（FL 插件需要这个版本的平台 API），再装 `vllm-ascend==0.23.0` 换成昇腾 `torch` 栈。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。
 
 ```shell #test id="install-vllm"
-python -m pip install --retries 3 vllm==0.23.0
+python -m pip install --retries 3 vllm==0.24.0
 python -m pip install \
   --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
   --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
@@ -85,7 +86,7 @@ for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
 ...
 torch 2.10.0...
 torch-npu 2.10.0.post4
-vllm 0.23.0...
+vllm 0.24.0...
 vllm-ascend 0.23.0
 ```
 

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -1,12 +1,12 @@
 # FlagScale
 
-在两张昇腾卡上安装 vLLM-Ascend，再装 FlagGems 与 vLLM FL 插件，用 FlagScale 对 [Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B) 做一次离线推理。
+在两张昇腾卡上安装 vLLM-Ascend，用 FlagScale 对 [Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B) 做一次离线推理。
 
 ## 前置条件
 
 ### 硬件
 
-Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为两张卡，tensor parallel 为 2。
+Atlas **800T** / **900 A2** 训练系列，芯片为 Ascend **910B**。本文示例为两张卡，tensor parallel 为 2。
 
 ### 软件
 
@@ -15,10 +15,8 @@ Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为�
 | CANN | toolkit + 驱动固件已安装，并可 `source set_env.sh` |
 | ATB | Ascend Transformer Boost。vLLM 子进程要加载 `libatb.so` |
 | Python | 3.12 |
-| vLLM | `0.24.0`，与 vllm-plugin-FL 对齐，见下文安装 |
-| vLLM-Ascend | `0.23.0`，只用来提供 `torch` / `torch-npu` / `triton-ascend` |
-| FlagGems | `v5.3.4`，见下文安装 |
-| vllm-plugin-FL | `v0.3.0-rc1.post1`，注册名 `fl` |
+| vLLM | `0.23.0` |
+| vLLM-Ascend | `0.23.0`，注册名 `ascend` |
 | FlagScale | 上游 Release tag，撰写时为 `v2.0.0` |
 | 模型 | [Qwen/Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B) |
 
@@ -64,10 +62,10 @@ Python 3.12...
 
 ## 3. 安装 vLLM-Ascend
 
-分三步安装，不要合成一次 `pip install`。先装社区 vLLM **0.24.0**（FL 插件需要这个版本的平台 API），再装 `vllm-ascend==0.23.0` 换成昇腾 `torch` 栈。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。社区 wheel 会带上 CUDA 通信库 `flashinfer`，昇腾上没有 `libcudart`，双卡初始化会失败，所以装完后卸掉。
+分三步安装，不要合成一次 `pip install`。先装社区 vLLM `0.23.0`，再装 `vllm-ascend==0.23.0` 换成昇腾 `torch` 栈。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。社区 wheel 会带上 CUDA 通信库 `flashinfer`，昇腾上没有 `libcudart`，双卡初始化会失败，所以装完后卸掉。
 
 ```shell #test id="install-vllm"
-python -m pip install --retries 3 vllm==0.24.0
+python -m pip install --retries 3 vllm==0.23.0
 python -m pip install \
   --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
   --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
@@ -87,60 +85,11 @@ for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
 ...
 torch 2.10.0...
 torch-npu 2.10.0.post4
-vllm 0.24.0...
+vllm 0.23.0...
 vllm-ascend 0.23.0
 ```
 
-## 4. 安装 FlagGems 与 vLLM FL 插件
-
-[FlagGems](https://github.com/flagos-ai/FlagGems) 提供算子，[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是注册名为 `fl` 的平台插件；与 `vllm-ascend` 同时存在时只激活一个，下文设 `VLLM_PLUGINS=fl`。这份插件 tag 和社区 vLLM 0.24 的注意力接口差两处，克隆后改完再安装。
-
-```shell #test id="install-flag-stack"
-python -m pip install scikit-build-core pybind11 ninja cmake sqlalchemy==2.0.48
-if [ ! -d FlagGems/.git ]; then
-  rm -rf FlagGems
-  GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
-    git clone --depth 1 --branch v5.3.4 \
-    https://github.com/flagos-ai/FlagGems.git FlagGems
-fi
-python -m pip install --no-build-isolation --no-deps ./FlagGems
-if [ ! -d vllm-plugin-FL/.git ]; then
-  rm -rf vllm-plugin-FL
-  GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
-    git clone --depth 1 --branch v0.3.0-rc1.post1 \
-    https://github.com/flagos-ai/vllm-plugin-FL.git vllm-plugin-FL
-fi
-python - <<'PY'
-from pathlib import Path
-p = Path("vllm-plugin-FL/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py")
-text = p.read_text()
-text = text.replace('return "ASCEND_FL"', 'return "CUSTOM"', 1)
-old = "    reorder_batch_threshold: ClassVar[int] = 1\n"
-new = (
-    "    reorder_batch_threshold: ClassVar[int] = 1\n"
-    "    supports_update_block_table: ClassVar[bool] = False\n"
-)
-if "supports_update_block_table" not in text:
-    if old not in text:
-        raise SystemExit("attention builder header missing")
-    text = text.replace(old, new, 1)
-p.write_text(text)
-PY
-python -m pip install --no-build-isolation --no-deps ./vllm-plugin-FL
-python -c "import flag_gems; from importlib.metadata import version; print('flag_gems', version('flag_gems')); print('vllm_fl', version('vllm-plugin-fl'))"
-```
-
-输出结果如下：
-
-```shell #test-result id="install-flag-stack"
-...
-flag_gems 5.3.4...
-vllm_fl 0.3...
-```
-
-导入 FlagGems 时可能看到 `get_device_capability returned None` 的警告，这是 `torch_npu` 的兼容性提示，不是安装失败。
-
-## 5. 安装 FlagScale
+## 4. 安装 FlagScale
 
 将 `<ref>` 换成目标 Release tag。克隆目录用 `FlagScale`，不要用当前目录下的 `flagscale/`，以免挡住已安装的包。`--no-deps` 避免元数据去拉一份不匹配的 torch。CLI 还需要 `hydra-core`、`omegaconf` 和 `typer`。`v2.0.0` 是 GitHub Release 的 tag 名；包装版本仍是 `1.0.0`，所以下面打印出来的是 `flagscale 1.0.0`。
 
@@ -171,61 +120,57 @@ python -c "from importlib.metadata import version; print('flagscale', version('f
 flagscale 1.0.0...
 ```
 
-## 6. 确认 FL 插件选中了 NPU
+## 5. 确认昇腾插件选中了 NPU
 
-推理前要设 `VLLM_PLUGINS=fl` 和 `VLLM_FL_PLATFORM=ascend`。不设时两个平台插件一起加载会直接报错，属预期行为。
+推理前设 `VLLM_PLUGINS=ascend`，让 vLLM 选用昇腾平台插件。
 
-保存为 `probe_fl_platform.py`：
+保存为 `probe_ascend_platform.py`：
 
 ```python
 import vllm
-import vllm_fl
+import vllm_ascend
 from vllm.platforms import current_platform as p
 
 print('vllm', vllm.__version__)
 print('platform_name', type(p).__name__)
 print('device_type', p.device_type)
-print('dist_backend', p.dist_backend)
 ```
 
 <!--
 ```shell #test-setup
-cat > probe_fl_platform.py <<'PY'
+cat > probe_ascend_platform.py <<'PY'
 import vllm
-import vllm_fl
+import vllm_ascend
 from vllm.platforms import current_platform as p
 
 print('vllm', vllm.__version__)
 print('platform_name', type(p).__name__)
 print('device_type', p.device_type)
-print('dist_backend', p.dist_backend)
 PY
 ```
 -->
 
 ```shell #test id="probe"
-export VLLM_PLUGINS=fl
-export VLLM_FL_PLATFORM=ascend
+export VLLM_PLUGINS=ascend
 export VLLM_LOGGING_LEVEL=INFO
 export ASCEND_RT_VISIBLE_DEVICES=0,1
-python probe_fl_platform.py 2>&1
+python probe_ascend_platform.py 2>&1
 ```
 
 输出结果如下：
 
 ```shell #test-result id="probe"
-...Platform plugin fl is activated...
-platform_name PlatformFL
+...Platform plugin ascend is activated...
+platform_name NPUPlatform
 device_type npu
-dist_backend hccl
 ...
 ```
 
-`device_type` 必须是 `npu`，`dist_backend` 必须是 `hccl`，`platform_name` 必须是 `PlatformFL`。若这里是 `cuda` / `cpu`，或插件名不是 `fl`，先回到第 4–5 节，不要开始推理。
+`device_type` 必须是 `npu`，`platform_name` 必须是 `NPUPlatform`。若这里是 `cuda` / `cpu`，或没有出现 `Platform plugin ascend is activated`，先回到第 3–4 节，不要开始推理。
 
-## 7. 用离线 inference 做一次双卡生成
+## 6. 用离线 inference 做一次双卡生成
 
-下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。当前 `triton-ascend` 编不了 FlagGems 5.3.4 的昇腾 kernel，所以设 `USE_FLAGGEMS=0`，算子改走 `torch_npu`。
+下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。
 
 保存为 `FlagScale/qs_conf/qwen25_05b_tp2_ascend.yaml`：
 
@@ -251,9 +196,7 @@ experiment:
     HCCL_CONNECT_TIMEOUT: 600
     PYTHONHASHSEED: 0
     VLLM_TARGET_DEVICE: "npu"
-    VLLM_PLUGINS: "fl"
-    VLLM_FL_PLATFORM: "ascend"
-    USE_FLAGGEMS: "0"
+    VLLM_PLUGINS: "ascend"
     VLLM_LOGGING_LEVEL: "INFO"
     VLLM_WORKER_MULTIPROC_METHOD: "spawn"
 
@@ -318,9 +261,7 @@ experiment:
     HCCL_CONNECT_TIMEOUT: 600
     PYTHONHASHSEED: 0
     VLLM_TARGET_DEVICE: "npu"
-    VLLM_PLUGINS: "fl"
-    VLLM_FL_PLATFORM: "ascend"
-    USE_FLAGGEMS: "0"
+    VLLM_PLUGINS: "ascend"
     VLLM_LOGGING_LEVEL: "INFO"
     VLLM_WORKER_MULTIPROC_METHOD: "spawn"
 
@@ -361,9 +302,7 @@ YAML
 
 ```shell #test id="inference"
 export PYTHONHASHSEED=0
-export VLLM_PLUGINS=fl
-export VLLM_FL_PLATFORM=ascend
-export USE_FLAGGEMS=0
+export VLLM_PLUGINS=ascend
 export VLLM_LOGGING_LEVEL=INFO
 export ASCEND_RT_VISIBLE_DEVICES=0,1
 export ASCEND_VISIBLE_DEVICES=0,1
@@ -375,8 +314,8 @@ flagscale inference qwen25_05b --config "$PWD/qs_conf/qwen25_05b_tp2_ascend.yaml
 输出结果如下：
 
 ```shell #test-result id="inference"
-...Platform plugin fl is activated...NPU compatibility enabled: torch.Event -> torch.npu.Event...backend=hccl...
+...Platform plugin ascend is activated...backend=hccl...
 output.outputs[0].text=...
 ```
 
-生成的文字每次可能不同，不必和样例一致。`Platform plugin fl is activated`、`NPU compatibility enabled`、`backend=hccl` 是这次走昇腾与两卡 HCCL 的证据；退出码 0 不算数，必须看到 `output.outputs[0].text=`。
+生成的文字每次可能不同，不必和样例一致。`Platform plugin ascend is activated`、`backend=hccl` 是这次走昇腾与两卡 HCCL 的证据；退出码 0 不算数，必须看到 `output.outputs[0].text=`。

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -215,7 +215,7 @@ dist_backend hccl
 
 ## 7. 用离线 inference 做一次双卡生成
 
-下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。`triton-ascend` 编不了 FlagGems 5.3.4 的昇腾 `pow` kernel，所以用 `VLLM_FL_FLAGOS_BLACKLIST_APPEND` 排除这几个算子，改走 `torch_npu`。
+下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。当前 `triton-ascend` 编不了 FlagGems 5.3.4 的昇腾 kernel，所以设 `USE_FLAGGEMS=0`，算子改走 `torch_npu`。
 
 保存为 `FlagScale/qs_conf/qwen25_05b_tp2_ascend.yaml`：
 
@@ -243,7 +243,7 @@ experiment:
     VLLM_TARGET_DEVICE: "npu"
     VLLM_PLUGINS: "fl"
     VLLM_FL_PLATFORM: "ascend"
-    VLLM_FL_FLAGOS_BLACKLIST_APPEND: "pow,pow_scalar,pow_tensor_scalar,pow_tensor_scalar_,pow_tensor_tensor,pow_tensor_tensor_"
+    USE_FLAGGEMS: "0"
     VLLM_LOGGING_LEVEL: "INFO"
     VLLM_WORKER_MULTIPROC_METHOD: "spawn"
 
@@ -310,7 +310,7 @@ experiment:
     VLLM_TARGET_DEVICE: "npu"
     VLLM_PLUGINS: "fl"
     VLLM_FL_PLATFORM: "ascend"
-    VLLM_FL_FLAGOS_BLACKLIST_APPEND: "pow,pow_scalar,pow_tensor_scalar,pow_tensor_scalar_,pow_tensor_tensor,pow_tensor_tensor_"
+    USE_FLAGGEMS: "0"
     VLLM_LOGGING_LEVEL: "INFO"
     VLLM_WORKER_MULTIPROC_METHOD: "spawn"
 
@@ -353,7 +353,7 @@ YAML
 export PYTHONHASHSEED=0
 export VLLM_PLUGINS=fl
 export VLLM_FL_PLATFORM=ascend
-export VLLM_FL_FLAGOS_BLACKLIST_APPEND=pow,pow_scalar,pow_tensor_scalar,pow_tensor_scalar_,pow_tensor_tensor,pow_tensor_tensor_
+export USE_FLAGGEMS=0
 export VLLM_LOGGING_LEVEL=INFO
 export ASCEND_RT_VISIBLE_DEVICES=0,1
 export ASCEND_VISIBLE_DEVICES=0,1

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -93,7 +93,7 @@ vllm-ascend 0.23.0
 
 ## 4. 安装 FlagGems 与 vLLM FL 插件
 
-[FlagGems](https://github.com/flagos-ai/FlagGems) 提供算子，[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是注册名为 `fl` 的平台插件；与 `vllm-ascend` 同时存在时只激活一个，下文设 `VLLM_PLUGINS=fl`。社区 vLLM 0.24 只接受名为 `CUSTOM` 的第三方注意力后端，克隆后改这一处再安装。
+[FlagGems](https://github.com/flagos-ai/FlagGems) 提供算子，[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是注册名为 `fl` 的平台插件；与 `vllm-ascend` 同时存在时只激活一个，下文设 `VLLM_PLUGINS=fl`。这份插件 tag 和社区 vLLM 0.24 的注意力接口差两处，克隆后改完再安装。
 
 ```shell #test id="install-flag-stack"
 python -m pip install scikit-build-core pybind11 ninja cmake sqlalchemy==2.0.48
@@ -114,7 +114,17 @@ python - <<'PY'
 from pathlib import Path
 p = Path("vllm-plugin-FL/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py")
 text = p.read_text()
-p.write_text(text.replace('return "ASCEND_FL"', 'return "CUSTOM"', 1))
+text = text.replace('return "ASCEND_FL"', 'return "CUSTOM"', 1)
+old = "    reorder_batch_threshold: ClassVar[int] = 1\n"
+new = (
+    "    reorder_batch_threshold: ClassVar[int] = 1\n"
+    "    supports_update_block_table: ClassVar[bool] = False\n"
+)
+if "supports_update_block_table" not in text:
+    if old not in text:
+        raise SystemExit("attention builder header missing")
+    text = text.replace(old, new, 1)
+p.write_text(text)
 PY
 python -m pip install --no-build-isolation --no-deps ./vllm-plugin-FL
 python -c "import flag_gems; from importlib.metadata import version; print('flag_gems', version('flag_gems')); print('vllm_fl', version('vllm-plugin-fl'))"

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -209,7 +209,7 @@ dist_backend hccl
 
 ## 7. 用离线 inference 做一次双卡生成
 
-下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。
+下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。`triton-ascend` 编不了 FlagGems 5.3.4 的昇腾 `pow` kernel，所以用 `VLLM_FL_FLAGOS_BLACKLIST_APPEND` 排除这几个算子，改走 `torch_npu`。
 
 保存为 `FlagScale/qs_conf/qwen25_05b_tp2_ascend.yaml`：
 
@@ -237,6 +237,7 @@ experiment:
     VLLM_TARGET_DEVICE: "npu"
     VLLM_PLUGINS: "fl"
     VLLM_FL_PLATFORM: "ascend"
+    VLLM_FL_FLAGOS_BLACKLIST_APPEND: "pow,pow_scalar,pow_tensor_scalar,pow_tensor_scalar_,pow_tensor_tensor,pow_tensor_tensor_"
     VLLM_LOGGING_LEVEL: "INFO"
     VLLM_WORKER_MULTIPROC_METHOD: "spawn"
 
@@ -304,6 +305,7 @@ experiment:
     VLLM_TARGET_DEVICE: "npu"
     VLLM_PLUGINS: "fl"
     VLLM_FL_PLATFORM: "ascend"
+    VLLM_FL_FLAGOS_BLACKLIST_APPEND: "pow,pow_scalar,pow_tensor_scalar,pow_tensor_scalar_,pow_tensor_tensor,pow_tensor_tensor_"
     VLLM_LOGGING_LEVEL: "INFO"
     VLLM_WORKER_MULTIPROC_METHOD: "spawn"
 
@@ -347,6 +349,7 @@ YAML
 export PYTHONHASHSEED=0
 export VLLM_PLUGINS=fl
 export VLLM_FL_PLATFORM=ascend
+export VLLM_FL_FLAGOS_BLACKLIST_APPEND=pow,pow_scalar,pow_tensor_scalar,pow_tensor_scalar_,pow_tensor_tensor,pow_tensor_tensor_
 export VLLM_LOGGING_LEVEL=INFO
 export ASCEND_RT_VISIBLE_DEVICES=0,1
 export ASCEND_VISIBLE_DEVICES=0,1

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -1,0 +1,375 @@
+# FlagScale
+
+在两张昇腾卡上安装 vLLM-Ascend，再装 FlagGems 与 vLLM FL 插件，用 FlagScale 对 [Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B) 做一次离线推理。
+
+## 前置条件
+
+### 硬件
+
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为两张卡，tensor parallel 为 2。
+
+### 软件
+
+| 类别 | 要求 |
+| --- | --- |
+| CANN | toolkit + 驱动固件已安装，并可 `source set_env.sh` |
+| ATB | Ascend Transformer Boost。vLLM 子进程要加载 `libatb.so` |
+| Python | 3.12 |
+| vLLM-Ascend | `vllm` / `vllm-ascend` 均为 `0.23.0`，见下文安装 |
+| FlagGems | `v5.3.4`，见下文安装 |
+| vllm-plugin-FL | `v0.3.0-rc1.post1`，注册名 `fl` |
+| FlagScale | 上游 Release tag，撰写时为 `v2.0.0` |
+| 模型 | [Qwen/Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B) |
+
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。推荐配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+## 1. 加载 CANN 环境
+
+常见容器里 `npu-smi` 在 `/usr/local/sbin`，需要把该目录加入 `PATH`。后面的 vLLM 还依赖 ATB。
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/latest/atb/set_env.sh
+export PATH=/usr/local/sbin:/usr/sbin:$PATH
+```
+
+## 2. 检查环境是否就绪
+
+### 2.1 确认 NPU 在线
+
+```shell
+npu-smi info
+```
+
+:::{note}
+表格里应能看到至少两张卡。若 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
+:::
+
+### 2.2 确认工具可用
+
+下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
+
+```shell #test id="check-tools"
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi >/dev/null
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-tools"
+Python 3.12...
+```
+
+## 3. 安装 vLLM-Ascend
+
+分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton，第一次推理报错。
+
+```shell #test id="install-vllm"
+python -m pip install --retries 3 vllm==0.23.0
+python -m pip install \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  vllm-ascend==0.23.0
+python -m pip install --force-reinstall --no-deps \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  triton-ascend==3.2.2
+python -c "import importlib.metadata as m
+for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
+    print(n, m.version(n))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-vllm"
+...
+torch 2.10.0...
+torch-npu 2.10.0.post4
+vllm 0.23.0...
+vllm-ascend 0.23.0
+```
+
+## 4. 安装 FlagGems 与 vLLM FL 插件
+
+[FlagGems](https://github.com/flagos-ai/FlagGems) 提供给 FL 插件调度的算子。[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是 vLLM 的平台插件，注册名 `fl`。环境里同时有 `vllm-ascend` 与 `fl` 时，一次只允许激活一个平台插件，下文会设 `VLLM_PLUGINS=fl`。
+
+```shell #test id="install-flag-stack"
+python -m pip install scikit-build-core pybind11 ninja cmake
+if [ ! -d FlagGems/.git ]; then
+  rm -rf FlagGems
+  GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
+    git clone --depth 1 --branch v5.3.4 \
+    https://github.com/flagos-ai/FlagGems.git FlagGems
+fi
+python -m pip install --no-build-isolation --no-deps ./FlagGems
+if [ ! -d vllm-plugin-FL/.git ]; then
+  rm -rf vllm-plugin-FL
+  GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
+    git clone --depth 1 --branch v0.3.0-rc1.post1 \
+    https://github.com/flagos-ai/vllm-plugin-FL.git vllm-plugin-FL
+fi
+python -m pip install --no-build-isolation --no-deps ./vllm-plugin-FL
+python -c "import flag_gems; from importlib.metadata import version; print('flag_gems', version('flag_gems')); print('vllm_fl', version('vllm-plugin-fl'))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-flag-stack"
+...
+flag_gems 5.3.4...
+vllm_fl 0.3...
+```
+
+导入 FlagGems 时可能看到 `get_device_capability returned None` 的警告，这是 `torch_npu` 的兼容性提示，不是安装失败。
+
+## 5. 安装 FlagScale
+
+将 `<ref>` 换成目标 Release tag。克隆目录用 `FlagScale`，不要用当前目录下的 `flagscale/`，以免挡住已安装的包。`--no-deps` 避免元数据去拉一份不匹配的 torch。CLI 还需要 `hydra-core`、`omegaconf` 和 `typer`。`v2.0.0` 是 GitHub Release 的 tag 名；包装版本仍是 `1.0.0`，所以下面打印出来的是 `flagscale 1.0.0`。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+```shell #test id="install-flagscale" load="upstream_ref>>ref"
+if [ ! -d FlagScale/.git ]; then
+  rm -rf FlagScale
+  GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
+    git clone --depth 1 --branch <ref> \
+    https://github.com/flagos-ai/FlagScale.git FlagScale
+fi
+git -C FlagScale describe --tags --exact-match
+python -m pip install --no-build-isolation --no-deps -e ./FlagScale
+python -m pip install hydra-core omegaconf typer pyyaml packaging
+python -c "from importlib.metadata import version; print('flagscale', version('flagscale'))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-flagscale" load="upstream_ref>>ref"
+<ref>
+...
+flagscale 1.0.0...
+```
+
+## 6. 确认 FL 插件选中了 NPU
+
+推理前要设 `VLLM_PLUGINS=fl` 和 `VLLM_FL_PLATFORM=ascend`。不设时两个平台插件一起加载会直接报错，属预期行为。
+
+保存为 `probe_fl_platform.py`：
+
+```python
+import vllm
+import vllm_fl
+from vllm.platforms import current_platform as p
+
+print('vllm', vllm.__version__)
+print('platform_name', type(p).__name__)
+print('device_type', p.device_type)
+print('dist_backend', p.dist_backend)
+```
+
+<!--
+```shell #test-setup
+cat > probe_fl_platform.py <<'PY'
+import vllm
+import vllm_fl
+from vllm.platforms import current_platform as p
+
+print('vllm', vllm.__version__)
+print('platform_name', type(p).__name__)
+print('device_type', p.device_type)
+print('dist_backend', p.dist_backend)
+PY
+```
+-->
+
+```shell #test id="probe"
+export VLLM_PLUGINS=fl
+export VLLM_FL_PLATFORM=ascend
+export VLLM_LOGGING_LEVEL=INFO
+export ASCEND_RT_VISIBLE_DEVICES=0,1
+python probe_fl_platform.py 2>&1
+```
+
+输出结果如下：
+
+```shell #test-result id="probe"
+...Platform plugin fl is activated...
+platform_name PlatformFL
+device_type npu
+dist_backend hccl
+...
+```
+
+`device_type` 必须是 `npu`，`dist_backend` 必须是 `hccl`，`platform_name` 必须是 `PlatformFL`。若这里是 `cuda` / `cpu`，或插件名不是 `fl`，先回到第 4–5 节，不要开始推理。
+
+## 7. 用离线 inference 做一次双卡生成
+
+下面的 yaml 把规模收到几分钟内可结束，仅供首次验证，不是生产配置。模型 id 走 Hugging Face Hub。`--test` 让推理在前台跑完才返回；末尾的 `2>&1` 把打在 stderr 的设备日志并进标准输出。
+
+保存为 `FlagScale/qs_conf/qwen25_05b_tp2_ascend.yaml`：
+
+```yaml
+defaults:
+  - _self_
+  - inference: qwen25_05b_tp2_ascend
+
+experiment:
+  exp_name: qwen25_05b
+  exp_dir: qs_out
+  task:
+    type: inference
+    backend: vllm
+    entrypoint: flagscale/inference/inference_llm.py
+  runner:
+    hostfile: null
+  envs:
+    HYDRA_FULL_ERROR: 1
+    ASCEND_VISIBLE_DEVICES: "0,1"
+    ASCEND_RT_VISIBLE_DEVICES: "0,1"
+    HCCL_WHITELIST_DISABLE: 1
+    HCCL_CONNECT_TIMEOUT: 600
+    PYTHONHASHSEED: 0
+    VLLM_TARGET_DEVICE: "npu"
+    VLLM_PLUGINS: "fl"
+    VLLM_FL_PLATFORM: "ascend"
+    VLLM_LOGGING_LEVEL: "INFO"
+    VLLM_WORKER_MULTIPROC_METHOD: "spawn"
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra
+```
+
+保存为 `FlagScale/qs_conf/inference/qwen25_05b_tp2_ascend.yaml`：
+
+```yaml
+llm:
+  model: Qwen/Qwen2.5-0.5B
+  tokenizer: Qwen/Qwen2.5-0.5B
+  trust_remote_code: true
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  gpu_memory_utilization: 0.4
+  seed: 1234
+  enforce_eager: true
+  max_model_len: 512
+  max_num_batched_tokens: 512
+  max_num_seqs: 1
+  attention_backend: "TORCH_SDPA"
+  disable_custom_all_reduce: true
+
+generate:
+  prompts: [
+    "The first President of the United States",
+  ]
+  sampling:
+    top_p: 0.1
+    top_k: 1
+    temperature: 0.0
+    seed: 1234
+    max_tokens: 8
+```
+
+<!--
+```shell #test-setup
+mkdir -p FlagScale/qs_conf/inference
+cat > FlagScale/qs_conf/qwen25_05b_tp2_ascend.yaml <<'YAML'
+defaults:
+  - _self_
+  - inference: qwen25_05b_tp2_ascend
+
+experiment:
+  exp_name: qwen25_05b
+  exp_dir: qs_out
+  task:
+    type: inference
+    backend: vllm
+    entrypoint: flagscale/inference/inference_llm.py
+  runner:
+    hostfile: null
+  envs:
+    HYDRA_FULL_ERROR: 1
+    ASCEND_VISIBLE_DEVICES: "0,1"
+    ASCEND_RT_VISIBLE_DEVICES: "0,1"
+    HCCL_WHITELIST_DISABLE: 1
+    HCCL_CONNECT_TIMEOUT: 600
+    PYTHONHASHSEED: 0
+    VLLM_TARGET_DEVICE: "npu"
+    VLLM_PLUGINS: "fl"
+    VLLM_FL_PLATFORM: "ascend"
+    VLLM_LOGGING_LEVEL: "INFO"
+    VLLM_WORKER_MULTIPROC_METHOD: "spawn"
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra
+YAML
+cat > FlagScale/qs_conf/inference/qwen25_05b_tp2_ascend.yaml <<'YAML'
+llm:
+  model: Qwen/Qwen2.5-0.5B
+  tokenizer: Qwen/Qwen2.5-0.5B
+  trust_remote_code: true
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  gpu_memory_utilization: 0.4
+  seed: 1234
+  enforce_eager: true
+  max_model_len: 512
+  max_num_batched_tokens: 512
+  max_num_seqs: 1
+  attention_backend: "TORCH_SDPA"
+  disable_custom_all_reduce: true
+
+generate:
+  prompts: [
+    "The first President of the United States",
+  ]
+  sampling:
+    top_p: 0.1
+    top_k: 1
+    temperature: 0.0
+    seed: 1234
+    max_tokens: 8
+YAML
+```
+-->
+
+```shell #test id="inference"
+export PYTHONHASHSEED=0
+export VLLM_PLUGINS=fl
+export VLLM_FL_PLATFORM=ascend
+export VLLM_LOGGING_LEVEL=INFO
+export ASCEND_RT_VISIBLE_DEVICES=0,1
+export ASCEND_VISIBLE_DEVICES=0,1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+cd FlagScale
+flagscale inference qwen25_05b --config "$PWD/qs_conf/qwen25_05b_tp2_ascend.yaml" --test 2>&1
+```
+
+输出结果如下：
+
+```shell #test-result id="inference"
+...Platform plugin fl is activated...NPU compatibility enabled: torch.Event -> torch.npu.Event...backend=hccl...
+output.outputs[0].text=...
+```
+
+生成的文字每次可能不同，不必和样例一致。`Platform plugin fl is activated`、`NPU compatibility enabled`、`backend=hccl` 是这次走昇腾与两卡 HCCL 的证据；退出码 0 不算数，必须看到 `output.outputs[0].text=`。
+
+## 故障排查
+
+| 现象 | 可能原因 | 建议 |
+| --- | --- | --- |
+| `Only one platform plugin can be activated` | 同时装了 ascend 与 fl，却没设 `VLLM_PLUGINS=fl` | 按第 6 节导出这两个变量 |
+| `device_type` 不是 `npu` | 插件没激活，或 `VLLM_FL_PLATFORM` 没设 | 重做第 4、6 节 |
+| EngineCore 报找不到 `libatb.so` | 只 source 了 toolkit，没 source ATB | 按第 1 节再加上 ATB 的 `set_env.sh` |
+| `Cannot re-initialize NPU in forked subprocess` | 没用 spawn | `export VLLM_WORKER_MULTIPROC_METHOD=spawn` |
+| `flagscale inference` 立刻返回、没有生成 | 没加 `--test`，runner 在后台启动 | 加上 `--test` |
+| 退出码 0 但没有 `output.outputs[0].text=` | 运行脚本末尾的 `sync` 把失败盖掉了 | 检查日志是否出现 `output.outputs[0].text=`，不要只看退出码 |
+| 只有一张卡可见 | 容器或环境没挂第二张卡 | 检查 `/dev/davinci1` 和 `ASCEND_RT_VISIBLE_DEVICES=0,1` |

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -94,7 +94,7 @@ vllm-ascend 0.23.0
 [FlagGems](https://github.com/flagos-ai/FlagGems) 提供给 FL 插件调度的算子。[vllm-plugin-FL](https://github.com/flagos-ai/vllm-plugin-FL) 是 vLLM 的平台插件，注册名 `fl`。环境里同时有 `vllm-ascend` 与 `fl` 时，一次只允许激活一个平台插件，下文会设 `VLLM_PLUGINS=fl`。
 
 ```shell #test id="install-flag-stack"
-python -m pip install scikit-build-core pybind11 ninja cmake
+python -m pip install scikit-build-core pybind11 ninja cmake sqlalchemy==2.0.48
 if [ ! -d FlagGems/.git ]; then
   rm -rf FlagGems
   GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -64,7 +64,7 @@ Python 3.12...
 
 ## 3. 安装 vLLM-Ascend
 
-分三步安装，不要合成一次 `pip install`。先装社区 vLLM **0.24.0**（FL 插件需要这个版本的平台 API），再装 `vllm-ascend==0.23.0` 换成昇腾 `torch` 栈。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。
+分三步安装，不要合成一次 `pip install`。先装社区 vLLM **0.24.0**（FL 插件需要这个版本的平台 API），再装 `vllm-ascend==0.23.0` 换成昇腾 `torch` 栈。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。社区 wheel 会带上 CUDA 通信库 `flashinfer`，昇腾上没有 `libcudart`，双卡初始化会失败，所以装完后卸掉。
 
 ```shell #test id="install-vllm"
 python -m pip install --retries 3 vllm==0.24.0
@@ -75,6 +75,7 @@ python -m pip install \
 python -m pip install --force-reinstall --no-deps \
   --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
   triton-ascend==3.2.2
+python -m pip uninstall -y flashinfer flashinfer-python flashinfer-cubin
 python -c "import importlib.metadata as m
 for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
     print(n, m.version(n))"

--- a/sources/flagscale/quick_start.md
+++ b/sources/flagscale/quick_start.md
@@ -63,7 +63,7 @@ Python 3.12...
 
 ## 3. 安装 vLLM-Ascend
 
-分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton，第一次推理报错。
+分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton。
 
 ```shell #test id="install-vllm"
 python -m pip install --retries 3 vllm==0.23.0
@@ -361,15 +361,3 @@ output.outputs[0].text=...
 ```
 
 生成的文字每次可能不同，不必和样例一致。`Platform plugin fl is activated`、`NPU compatibility enabled`、`backend=hccl` 是这次走昇腾与两卡 HCCL 的证据；退出码 0 不算数，必须看到 `output.outputs[0].text=`。
-
-## 故障排查
-
-| 现象 | 可能原因 | 建议 |
-| --- | --- | --- |
-| `Only one platform plugin can be activated` | 同时装了 ascend 与 fl，却没设 `VLLM_PLUGINS=fl` | 按第 6 节导出这两个变量 |
-| `device_type` 不是 `npu` | 插件没激活，或 `VLLM_FL_PLATFORM` 没设 | 重做第 4、6 节 |
-| EngineCore 报找不到 `libatb.so` | 只 source 了 toolkit，没 source ATB | 按第 1 节再加上 ATB 的 `set_env.sh` |
-| `Cannot re-initialize NPU in forked subprocess` | 没用 spawn | `export VLLM_WORKER_MULTIPROC_METHOD=spawn` |
-| `flagscale inference` 立刻返回、没有生成 | 没加 `--test`，runner 在后台启动 | 加上 `--test` |
-| 退出码 0 但没有 `output.outputs[0].text=` | 运行脚本末尾的 `sync` 把失败盖掉了 | 检查日志是否出现 `output.outputs[0].text=`，不要只看退出码 |
-| 只有一张卡可见 | 容器或环境没挂第二张卡 | 检查 `/dev/davinci1` 和 `ASCEND_RT_VISIBLE_DEVICES=0,1` |

--- a/tests/flagscale/__init__.py
+++ b/tests/flagscale/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent ``__init__.py``
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/flagscale/__init__.py -> parents[0]=tests/flagscale,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/flagscale/test_quick_start_ascend.py
+++ b/tests/flagscale/test_quick_start_ascend.py
@@ -1,0 +1,132 @@
+"""Quick-start test: doc under test is ``sources/flagscale/quick_start.md``.
+
+Run: ``python -m unittest tests.flagscale.test_quick_start_ascend -v 2>&1``
+
+Env (injected by the engine ``quick-start-template.yml``, triggered by
+``flagscale-quick-start.yml``): ``MONITORED_DOC_URL``, ``UPSTREAM_REF``,
+``NPU_READY=true`` (otherwise the class is skipped).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    ensure_safetensors,
+    purge_huggingface_corrupt,
+    report_huggingface_state,
+    resolve_huggingface_cache,
+)
+
+_CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+_ATB_SET_ENV = '/usr/local/Ascend/nnal/atb/latest/atb/set_env.sh'
+
+
+def _is_truthy(value: str | None) -> bool:
+    """``'true'`` -> True (case-insensitive); anything else (including unset) -> False."""
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    """Return True when ``NPU_READY=true`` is set, releasing the skip."""
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    """End-to-end test: fetch doc -> validate contract -> run ``#test-setup``
+    / ``#test`` in order -> compare against ``#test-result``."""
+
+    DEFAULT_COMMAND_TIMEOUT = 7200
+    USER_AGENT = 'ascend-docs/quick-start'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'HostRegisterError',
+        'ERR99999',
+    )
+
+    _MODEL_ID = 'Qwen/Qwen2.5-0.5B'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN / ATB once so later ``bash -c`` blocks inherit them.
+
+        Class-level setup: run once per test class, triggered by
+        ``setUpClass``. Each labeled fence is a new subprocess, so a
+        ``source set_env.sh`` block in the document does not persist.
+
+        Merge is overwrite, not ``setdefault``: the container image may
+        already ship ``LD_LIBRARY_PATH``, which would otherwise hide the
+        CANN increment from ``set_env.sh``.
+        """
+        venv_prefix = ''
+        virtual_env = os.environ.get('VIRTUAL_ENV')
+        if virtual_env:
+            venv_prefix = str(Path(virtual_env) / 'bin')
+
+        missing = [p for p in (_CANN_SET_ENV, _ATB_SET_ENV) if not os.path.isfile(p)]
+        if missing:
+            raise RuntimeError(
+                'required Ascend env scripts missing: ' + ', '.join(missing)
+            )
+        sourced = ' && '.join(
+            f'set +u && source {shlex.quote(script)} >/dev/null 2>&1'
+            for script in (_CANN_SET_ENV, _ATB_SET_ENV)
+        )
+        merged = subprocess.run(
+            ['bash', '-c', f'{sourced}; env'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            os.environ[key] = value
+        extras = []
+        for extra in ('/usr/local/sbin', '/usr/local/bin', '/usr/sbin'):
+            parts = os.environ.get('PATH', '').split(':')
+            if extra not in parts:
+                extras.append(extra)
+        if extras:
+            os.environ['PATH'] = os.environ.get('PATH', '') + ':' + ':'.join(extras)
+        if venv_prefix:
+            current = os.environ.get('PATH', '')
+            if not current.startswith(venv_prefix + ':'):
+                os.environ['PATH'] = f'{venv_prefix}:{current}'
+        print('setup: sourced CANN and ATB env')
+
+        ensure_safetensors()
+        report_huggingface_state(cls._MODEL_ID)
+        purge_huggingface_corrupt(resolve_huggingface_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing when
+        ``NPU_READY`` is unset.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Run the full pre_process -> parse -> execute -> post_process flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- 把 `flagos-ai/FlagScale` 昇腾 Quick Start 迁到 `sources/flagscale/`。装 vLLM 改为统一三步 pip（`vllm` / `vllm-ascend` 0.23.0，最后强制重装 `triton-ascend`），不再源码编译 vLLM / vllm-ascend；模型改为 Hugging Face `Qwen/Qwen2.5-0.5B`；双卡离线推理的预期输出含 `device_type npu`、`backend=hccl` 与 `output.outputs[0].text=`。
- 接入共享引擎：薄触发器 `flagscale-quick-start.yml`（`linux-aarch64-a2-2`，不传 `container_options` / `--volume`）+ `tests/flagscale` 子类；首页推理区增加卡片和 toctree。

## 相对源仓的刻意差异
- 源仓用 ModelScope、GitHub 代理、`--volume` 和 `VLLM_TARGET_DEVICE=empty` 源码编译。香港 A2 直连官方 URL，模型走 Hub 默认缓存。
- `vllm-plugin-FL` 官方表是 `0.20.2` 或 `0.24.0`。本文跟已跑通的文档引擎配了对，钉 `vLLM 0.23.0` 官方 wheel，插件用接近 0.24 的 `v0.3.0-rc1.post1`。若 NPU 上插件 API 对不上，再单独改插件 tag，不要退回源码编 vLLM。

## Test plan
- [x] 本机解析块数 > 0（6 条 `#test` + 3 条 `#test-setup`）、可见正文泄漏检查、`actionlint`、测试文件 `py_compile`
- [ ] 合入后在香港 A2 上 `workflow_dispatch` 跑冷/热缓存；fork PR 的 `doc_url` 会 404，属预期
- [ ] 探针块出现 `platform_name PlatformFL` / `device_type npu` / `dist_backend hccl`；推理块出现 `backend=hccl` 与 `output.outputs[0].text=`
- [ ] 热缓存下 Hugging Face Hub 的 0.5B 权重应命中 `/root/.cache/huggingface/hub`，可见块不再完整下载