### PR TITLE
docs(internlm): migrate main-branch NPU quick start guard

### DIFF
--- a/.github/workflows/internlm-quick-start.yml
+++ b/.github/workflows/internlm-quick-start.yml
@@ -1,0 +1,37 @@
+# InternLM Ascend Quick Start guard. The NPU guide postdates the latest release,
+# so the shared engine monitors upstream main's commit SHA through fixed_ref.
+name: internlm-quick-start
+
+concurrency:
+  group: internlm-quick-start
+  cancel-in-progress: false
+
+on:
+  schedule:
+    - cron: '35 */12 * * *'
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/internlm/**'
+      - 'tests/internlm/**'
+      - '.github/workflows/internlm-quick-start.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  internlm-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      project: internlm
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      container_options: >-
+        --volume=/data/ci-cache/modelscope/internlm:/root/.cache/modelscope
+      timeout_minutes: 180
+      upstream_repo: InternLM/InternLM
+      fixed_ref: main
+      doc_url: 'https://api.github.com/repos/Ascend/docs/contents/sources/internlm/quick_start.md?ref={0}'
+      doc_path: https://github.com/Ascend/docs/blob/${{ github.sha }}/sources/internlm/quick_start.md
+      test_command: python -m unittest tests.internlm.test_quick_start_ascend -v 2>&1

--- a/.github/workflows/quick-start-template.yml
+++ b/.github/workflows/quick-start-template.yml
@@ -70,6 +70,10 @@ on:
         description: Upstream repo (owner/name) polled for releases; recorded as target_repo in result.json
         type: string
         required: true
+      fixed_ref:
+        description: Optional upstream tag, branch, or SHA to test instead of resolving the latest release; its commit SHA is monitored for changes
+        type: string
+        default: ''
       doc_url:
         description: URL of the monitored quick-start doc; the monitor hashes it and the test fetches the same URL
         type: string
@@ -162,6 +166,7 @@ jobs:
       # Engine-fixed env: upstream repo + monitored doc come from the
       # caller's inputs (caller env does not cross the `uses:` boundary).
       UPSTREAM_REPO: ${{ inputs.upstream_repo }}
+      FIXED_REF: ${{ inputs.fixed_ref }}
       MONITORED_DOC_URL: ${{ format(inputs.doc_url, github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main') }}
       GH_TOKEN: ${{ github.token }}
       GH_API: https://api.github.com
@@ -263,7 +268,9 @@ jobs:
           echo "monitor cache: release(id=$last_release_id) doc(hash=$doc_hash) test(result=$test_result error=$test_error)"
 
           # ----- release signal -----
-          # Automatic fallback chain — no caller input needed:
+          # A caller-provided FIXED_REF is resolved to its current commit SHA so
+          # mutable branches still fire the change signal. Without FIXED_REF,
+          # use the automatic fallback chain:
           #   1. /releases/latest          (default path; most upstreams)
           #   2. /releases?per_page=20     (covers prerelease-only repos, e.g.
           #                                 torchtitan pre-stable where
@@ -298,7 +305,20 @@ jobs:
           # at one step falls through cleanly to the next instead of
           # aborting the whole monitor cycle.
           : > /tmp/release.json  # start empty; each step either writes or leaves empty
-          if curl -fsSL --retry 3 --max-time 30 \
+          if [ -n "$FIXED_REF" ]; then
+            if curl -fsSL --retry 3 --max-time 30 \
+                "$GH_API/repos/${{ env.UPSTREAM_REPO }}/commits/$FIXED_REF" \
+                -o /tmp/fixed-ref.json 2>/dev/null; then
+              jq --arg ref "$FIXED_REF" \
+                '{id: (.sha // ""), tag_name: $ref}' \
+                /tmp/fixed-ref.json > /tmp/release.json
+              echo "monitor: release source=/commits/$FIXED_REF (caller-fixed ref)"
+            else
+              jq -n --arg ref "$FIXED_REF" \
+                '{id: "", tag_name: $ref}' > /tmp/release.json
+              echo "monitor: failed to resolve fixed ref $FIXED_REF; release signal unavailable"
+            fi
+          elif curl -fsSL --retry 3 --max-time 30 \
               "$GH_API/repos/${{ env.UPSTREAM_REPO }}/releases/latest" -o /tmp/r1.json 2>/dev/null \
               && jq -e '.tag_name // empty' /tmp/r1.json > /dev/null 2>&1; then
             mv /tmp/r1.json /tmp/release.json
@@ -450,13 +470,23 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             need_to_test="true"
             reason="manual"
-            ref=$(resolve_ref)
+            if [ -n "$FIXED_REF" ]; then
+              ref="$FIXED_REF"
+              echo "monitor: ref source=caller-fixed ref ($ref)"
+            else
+              ref=$(resolve_ref)
+            fi
             [ -n "$ref" ] || { echo "ERROR: failed to resolve latest upstream ref (auto-fallback chain exhausted)"; exit 1; }
             echo "monitor decision (manual override): ref=$ref need_to_test=true reason=manual"
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             need_to_test="true"
             reason="pr"
-            ref=$(resolve_ref)
+            if [ -n "$FIXED_REF" ]; then
+              ref="$FIXED_REF"
+              echo "monitor: ref source=caller-fixed ref ($ref)"
+            else
+              ref=$(resolve_ref)
+            fi
             [ -n "$ref" ] || { echo "ERROR: failed to resolve latest upstream ref for PR run (auto-fallback chain exhausted)"; exit 1; }
             echo "monitor decision (pr run): ref=$ref need_to_test=true reason=pr"
           elif [ -f $DECISION_FILE ]; then

--- a/index.rst
+++ b/index.rst
@@ -257,6 +257,13 @@
          <div class="card-footer"><a href="https://github.com/InternLM/lmdeploy">官方链接</a><span class="split">|</span><a href="https://lmdeploy.readthedocs.io/en/latest/">文档中心</a><span class="split">|</span><a href="https://lmdeploy.readthedocs.io/en/latest/get_started/ascend/get_started.html">昇腾教程</a></div>
       </div>
 
+      <!-- InternLM -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/huggingface.png')"></div><h3 class="card-title">InternLM</h3></div>
+         <p class="card-desc">开源大语言模型系列，支持在昇腾 NPU 上进行 Transformers 推理。</p>
+         <div class="card-footer"><a href="https://github.com/InternLM/InternLM">官方链接</a><span class="split">|</span><a href="https://github.com/InternLM/InternLM/blob/main/ecosystem/README_npu.md">NPU 指南</a><span class="split">|</span><a href="sources/internlm/quick_start.html">快速上手</a></div>
+      </div>
+
       <!-- ONNX Runtime：官方文档站已含 CANN/昇腾说明，外链跳转，不再本地编译 -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/onnxruntime.png')"></div><h3 class="card-title">onnxruntime</h3></div>
@@ -426,6 +433,7 @@
    :caption: 🚀 推理与服务
 
    sources/llama_cpp/index.rst
+   sources/internlm/index.md
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst
    sources/sentence_transformers/index.rst
@@ -455,4 +463,3 @@
    sources/timm/index.rst
    sources/wenet/index.rst
    sources/whisper_cpp/index.rst
-

--- a/sources/internlm/index.md
+++ b/sources/internlm/index.md
@@ -1,0 +1,6 @@
+# InternLM
+
+InternLM 通用文档由上游社区维护。本页收录经过持续验证的 Ascend NPU 快速上手。
+
+```{include} quick_start.md
+```

--- a/sources/internlm/quick_start.md
+++ b/sources/internlm/quick_start.md
@@ -1,0 +1,220 @@
+# 快速开始
+
+在单张昇腾 NPU 上运行 [InternLM](https://github.com/InternLM/InternLM)
+上游 `ecosystem/README_npu.md` 中的 Transformers 推理链路：下载
+InternLM3-8B-Instruct，以 FP16 加载到 `npu:0`，并完成一次确定性的文本生成。
+
+## 前置条件
+
+### 硬件
+
+Atlas 900 A2 / A3 训练系列产品或者其他兼容的 Ascend NPU，至少有一张可用
+设备，并已完成驱动和设备配置。CI 使用 `linux-aarch64-a2-1` Runner，由 Runner
+自动提供一张配置完好的 NPU，不需要额外传入设备挂载参数。
+
+### 基础软件
+
+运行本文档之前，需要准备：
+
+- Linux aarch64 和 Python 3.12；
+- CANN toolkit、驱动和 `npu-smi`；
+- 与 CANN 匹配的 PyTorch 和 PyTorch-NPU；
+- 至少约 20 GB 的模型缓存空间，并能访问 GitHub 和 ModelScope。
+
+### 本文档示例使用的版本
+
+| 组件 | 版本 |
+| --- | --- |
+| Python | 3.12 |
+| CANN | 9.1.0 |
+| torch | 2.9.0+cpu |
+| torch_npu | 2.9.0.post2 |
+| transformers | 4.48.0 |
+| modelscope | 1.37.0 |
+| InternLM | `main`，由工作流解析并监控其 commit SHA |
+| 模型 | `Shanghai_AI_Laboratory/internlm3-8b-instruct` |
+| 精度 | FP16 |
+| NPU | Ascend 910B4 × 1 |
+
+上游最近的 GitHub release 早于 InternLM3 的 NPU 指南，因此本文不使用旧 release，
+而是由工作流注入并持续监控 `main`。依赖版本则固定为本 Quick Start 的已知兼容栈，
+避免包的自动升级改变验证结果。
+
+### 检查前置条件
+
+检查 Python：
+
+```shell #test id="check-python"
+python --version
+```
+
+```shell #test-result id="check-python" fuzzy="xxx"
+Python 3.12.xxx
+```
+
+检查 PyTorch-NPU 和当前可见设备：
+
+```shell #test id="check-torch"
+python - <<'PY'
+import torch
+import torch_npu
+
+assert torch.npu.is_available()
+assert torch.npu.device_count() == 1
+print("torch:", torch.__version__)
+print("torch_npu:", torch_npu.__version__)
+print("npu_available:", torch.npu.is_available())
+print("npu_count:", torch.npu.device_count())
+PY
+```
+
+```shell #test-result id="check-torch" fuzzy="xxx"
+torch: 2.9.0xxx
+torch_npu: 2.9.0.post2
+npu_available: True
+npu_count: 1
+```
+
+## 获取 InternLM 上游源码
+
+工作流把受监控的上游分支写入 `UPSTREAM_REF`。下面 checkout 同一个 ref，并确认
+其中确实包含 InternLM3-8B-Instruct 的官方 NPU Transformers 示例。
+
+<!--
+```shell #test-setup store="upstream_ref"
+printf '%s\n' "$UPSTREAM_REF"
+```
+-->
+
+```shell #test id="checkout-upstream" load="upstream_ref>>ref"
+git clone --depth 1 --branch <ref> https://github.com/InternLM/InternLM.git internlm-src
+grep -Fq 'InternLM3-8B-Instruct' internlm-src/ecosystem/README_npu.md
+grep -Fq ').npu()' internlm-src/ecosystem/README_npu.md
+printf 'InternLM checkout: %s\n' "$(git -C internlm-src rev-parse --short HEAD)"
+echo "upstream NPU guide: OK"
+```
+
+```shell #test-result id="checkout-upstream" fuzzy="xxx"
+InternLM checkout: xxx
+upstream NPU guide: OK
+```
+
+## 安装推理依赖
+
+InternLM3 的模型卡要求 Transformers 4.48 或更新版本。这里采用上游 NPU 指南
+对应的 4.48.0，并固定 ModelScope 版本；`torch` 与 `torch_npu` 属于前置环境，
+不在这一步重复替换。
+
+```shell #test id="install-deps"
+uv pip install \
+  "transformers==4.48.0" \
+  "modelscope==1.37.0" \
+  sentencepiece \
+  safetensors
+python - <<'PY'
+import modelscope
+import transformers
+
+print("transformers:", transformers.__version__)
+print("modelscope:", modelscope.__version__)
+PY
+```
+
+```shell #test-result id="install-deps"
+...transformers: 4.48.0
+modelscope: 1.37.0
+```
+
+## 下载 InternLM3-8B-Instruct
+
+通过上游 Model Zoo 提供的 ModelScope 仓库下载模型。CI 将 ModelScope 默认缓存目录
+挂载到持久化磁盘；首次运行需要下载模型，后续运行复用已校验的缓存。
+
+```shell #test id="download-model"
+set -euo pipefail
+mkdir -p /root/internlm-quick-start
+model_dir="$(python - <<'PY' | sed -n 's/^MODEL_DIR=//p' | tail -n 1
+from modelscope import snapshot_download
+
+model_dir = snapshot_download("Shanghai_AI_Laboratory/internlm3-8b-instruct")
+print(f"MODEL_DIR={model_dir}")
+PY
+)"
+test -n "$model_dir"
+test -f "$model_dir/config.json"
+ln -sfn "$model_dir" /root/internlm-quick-start/model
+echo "model: /root/internlm-quick-start/model/config.json"
+```
+
+```shell #test-result id="download-model"
+model: /root/internlm-quick-start/model/config.json
+```
+
+## Quick Start：单卡 NPU 推理
+
+以下流程保留上游示例的 `AutoTokenizer`、`AutoModelForCausalLM`、chat template、
+FP16 和 `.npu()`。为了让持续集成的耗时和输出稳定，将生成长度缩短为 64 token，
+并关闭随机采样；测试只验证设备、生成 token 数和非空响应，不绑定具体自然语言答案。
+
+```shell #test id="npu-inference"
+python - <<'PY'
+import torch
+import torch_npu
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model_dir = "/root/internlm-quick-start/model"
+tokenizer = AutoTokenizer.from_pretrained(model_dir, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(
+    model_dir,
+    trust_remote_code=True,
+    torch_dtype=torch.float16,
+).npu()
+model.eval()
+
+messages = [
+    {
+        "role": "system",
+        "content": "You are InternLM, a helpful, honest, and harmless AI assistant.",
+    },
+    {"role": "user", "content": "Please name one scenic spot in Shanghai."},
+]
+tokenized_chat = tokenizer.apply_chat_template(
+    messages,
+    tokenize=True,
+    add_generation_prompt=True,
+    return_tensors="pt",
+).npu()
+
+with torch.inference_mode():
+    generated_ids = model.generate(
+        tokenized_chat,
+        max_new_tokens=64,
+        do_sample=False,
+    )
+torch.npu.synchronize()
+
+new_tokens = generated_ids[:, tokenized_chat.shape[-1]:]
+response = tokenizer.batch_decode(new_tokens, skip_special_tokens=True)[0].strip()
+model_device = next(model.parameters()).device
+
+assert model_device.type == "npu"
+assert tokenized_chat.device.type == "npu"
+assert new_tokens.shape[-1] > 0
+assert response
+
+print("model device:", model_device)
+print("generated tokens:", new_tokens.shape[-1])
+print("response:", response.replace("\n", " "))
+print("NPU inference PASSED")
+PY
+```
+
+```shell #test-result id="npu-inference" fuzzy="xxx"
+model device: npu:0
+generated tokens: xxx
+response: xxx
+NPU inference PASSED
+```
+
+本 Quick Start 只看护 InternLM 上游已经存在的单卡 Transformers NPU 推理入口，
+不覆盖多卡 HCCL、量化、服务部署以及外部训练框架。

--- a/tests/doc_test/test_quick_start_template_contract.py
+++ b/tests/doc_test/test_quick_start_template_contract.py
@@ -1,0 +1,30 @@
+"""Static contract for fixed upstream refs in the shared Quick Start guard."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = ROOT / ".github" / "workflows" / "quick-start-template.yml"
+
+
+class TestQuickStartTemplateContract(unittest.TestCase):
+    def test_fixed_ref_is_optional_and_propagated_to_the_test_job(self) -> None:
+        text = TEMPLATE.read_text(encoding="utf-8")
+
+        self.assertIn("fixed_ref:", text)
+        self.assertIn("default: ''", text)
+        self.assertIn("FIXED_REF: ${{ inputs.fixed_ref }}", text)
+
+    def test_fixed_ref_commit_sha_drives_scheduled_change_detection(self) -> None:
+        text = TEMPLATE.read_text(encoding="utf-8")
+
+        self.assertIn('commits/$FIXED_REF', text)
+        self.assertIn("caller-fixed ref", text)
+        self.assertIn("ref=\"$FIXED_REF\"", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/internlm/__init__.py
+++ b/tests/internlm/__init__.py
@@ -1,0 +1,12 @@
+"""InternLM Quick Start tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / "tests"
+for _path in (_TESTS_ROOT, _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))

--- a/tests/internlm/constraints-npu.txt
+++ b/tests/internlm/constraints-npu.txt
@@ -1,0 +1,45 @@
+# Keep dependency resolution on the CANN 9.1 / torch 2.9 stack validated by
+# this guard. InternLM3's upstream model card and NPU guide require the
+# Transformers 4.48 generation.
+torch==2.9.0
+torch-npu==2.9.0.post2
+transformers==4.48.0
+modelscope==1.37.0
+cuda-toolkit<0
+cuda-python<0
+cuda-bindings<0
+cuda-core<0
+cuda-pathfinder<0
+flashinfer-python<0
+nvidia-cublas<0
+nvidia-cuda-runtime<0
+nvidia-cuda-nvrtc<0
+nvidia-cuda-cupti<0
+nvidia-cudnn<0
+nvidia-cudnn-frontend<0
+nvidia-cufft<0
+nvidia-curand<0
+nvidia-cusolver<0
+nvidia-cusparse<0
+nvidia-cutlass-dsl<0
+nvidia-cutlass-dsl-libs-base<0
+nvidia-cutlass-dsl-libs-core<0
+nvidia-cutlass-dsl-libs-cu12<0
+nvidia-ml-py<0
+nvidia-nccl<0
+nvidia-nvjitlink<0
+nvidia-nvtx<0
+nvidia-cublas-cu12<0
+nvidia-cuda-nvdisasm<0
+nvidia-cuda-runtime-cu12<0
+nvidia-cuda-nvrtc-cu12<0
+nvidia-cuda-cupti-cu12<0
+nvidia-cudnn-cu12<0
+nvidia-cufft-cu12<0
+nvidia-curand-cu12<0
+nvidia-cusolver-cu12<0
+nvidia-cusparse-cu12<0
+nvidia-cusparselt-cu12<0
+nvidia-nccl-cu12<0
+nvidia-nvjitlink-cu12<0
+nvidia-nvtx-cu12<0

--- a/tests/internlm/test_project_contract.py
+++ b/tests/internlm/test_project_contract.py
@@ -1,0 +1,51 @@
+"""Static contract for the migrated InternLM Quick Start."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "sources" / "internlm" / "quick_start.md"
+WORKFLOW = ROOT / ".github" / "workflows" / "internlm-quick-start.yml"
+
+
+class TestProjectContract(unittest.TestCase):
+    def test_document_keeps_the_upstream_main_npu_inference(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        test_ids = set(re.findall(r'#test id="([^"]+)"', text))
+        result_ids = set(re.findall(r'#test-result id="([^"]+)"', text))
+
+        self.assertEqual(
+            test_ids,
+            {"check-python", "check-torch", "checkout-upstream", "install-deps", "download-model", "npu-inference"},
+        )
+        self.assertEqual(result_ids, test_ids)
+        self.assertIn("ecosystem/README_npu.md", text)
+        self.assertIn("internlm3-8b-instruct", text)
+        self.assertIn(").npu()", text)
+        self.assertNotIn("bitsandbytes", text)
+
+    def test_workflow_tracks_main_and_serializes_the_model_cache(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("group: internlm-quick-start", text)
+        self.assertIn("project: internlm", text)
+        self.assertIn("fixed_ref: main", text)
+        self.assertIn("linux-aarch64-a2-1", text)
+        self.assertIn("/data/ci-cache/modelscope/internlm", text)
+        self.assertIn("timeout_minutes: 180", text)
+        self.assertIn("upstream_repo: InternLM/InternLM", text)
+        self.assertIn("tests.internlm.test_quick_start_ascend", text)
+
+    def test_project_is_reachable_from_the_site_navigation(self) -> None:
+        index = (ROOT / "index.rst").read_text(encoding="utf-8")
+
+        self.assertIn("sources/internlm/index.md", index)
+        self.assertIn("sources/internlm/quick_start.html", index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/internlm/test_quick_start_ascend.py
+++ b/tests/internlm/test_quick_start_ascend.py
@@ -1,0 +1,123 @@
+"""End-to-end test for the InternLM Ascend Quick Start document."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    ensure_safetensors,
+    purge_modelscope_corrupt,
+    resolve_modelscope_cache,
+)
+
+
+def _e2e_enabled() -> bool:
+    return os.environ.get("NPU_READY", "").strip().lower() == "true"
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    DEFAULT_COMMAND_TIMEOUT = 7200
+    USER_AGENT = "Ascend/docs/internlm-quick-start"
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        "applicaiton exception",
+        "ERR99999",
+    )
+
+    _CANN_SET_ENV = "/usr/local/Ascend/ascend-toolkit/set_env.sh"
+    _CLUSTER_INDEX = (
+        "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+    )
+    _ASCEND_EXTRA = "https://repo.huaweicloud.com/ascend/repos/pypi"
+    _CONSTRAINTS_FILE = Path(__file__).resolve().parent / "constraints-npu.txt"
+
+    def pre_process(self) -> str:
+        doc_path = (
+            Path(__file__).resolve().parents[2]
+            / "sources"
+            / "internlm"
+            / "quick_start.md"
+        )
+        if not doc_path.is_file():
+            raise RuntimeError(f"Quick Start document not found: {doc_path}")
+        return doc_path.read_text(encoding="utf-8")
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        if not os.path.isfile(cls._CANN_SET_ENV):
+            raise RuntimeError(f"CANN environment script not found: {cls._CANN_SET_ENV}")
+
+        merged = subprocess.run(
+            ["bash", "-c", f"source {cls._CANN_SET_ENV} >/dev/null 2>&1; env"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            os.environ.setdefault(key, value)
+
+        os.environ["PIP_CONSTRAINT"] = str(cls._CONSTRAINTS_FILE)
+        os.environ["UV_CONSTRAINT"] = str(cls._CONSTRAINTS_FILE)
+        os.environ["PYTHONNOUSERSITE"] = "1"
+        os.environ.setdefault("ASCEND_RT_VISIBLE_DEVICES", "0")
+        os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+        subprocess.run(["python", "-m", "pip", "install", "uv"], check=True)
+
+        probe = subprocess.run(
+            [
+                "python",
+                "-c",
+                "import torch, torch_npu; "
+                "raise SystemExit(0 if "
+                "torch.__version__.startswith('2.9.0') and "
+                "torch_npu.__version__.startswith('2.9.0') else 1)",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if probe.returncode != 0:
+            print("setup: installing torch==2.9.0 torch_npu==2.9.0.post2")
+            subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "pip",
+                    "install",
+                    "--index-url",
+                    cls._CLUSTER_INDEX,
+                    "--extra-index-url",
+                    cls._ASCEND_EXTRA,
+                    "torch==2.9.0",
+                    "torch_npu==2.9.0.post2",
+                ],
+                check=True,
+            )
+        else:
+            print("setup: reusing torch 2.9 / torch_npu 2.9 stack")
+
+        ensure_safetensors()
+        purge_modelscope_corrupt(resolve_modelscope_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        "end-to-end requires an Ascend NPU runner; set NPU_READY=true",
+    )
+    def test_runs_doc(self) -> None:
+        self.run_template()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add optional `fixed_ref` support to the shared Quick Start engine in a dedicated first commit
- migrate the validated InternLM3 single-NPU Transformers inference guide into `sources/internlm`
- add dependency constraints, ModelScope cache validation, the project test, and the thin workflow caller
- add InternLM to the inference/service homepage section and Sphinx navigation

## Why fixed_ref

InternLM's current NPU guide postdates its latest GitHub release. The guard therefore tracks `main`; scheduled runs resolve that branch to its current commit SHA for change detection, while manual and PR runs use the same branch ref. Projects that omit `fixed_ref` keep the existing latest-release behavior.

## Validation

- `python -m unittest tests.doc_test.test_quick_start_template_contract tests.internlm.test_project_contract tests.internlm.test_quick_start_ascend -v`
- parsed the Markdown contract with 7 executable commands and 6 expected-output blocks
- `actionlint .github/workflows/internlm-quick-start.yml`
- the shared template reports only its existing dynamic-source shellcheck warnings
- Sphinx HTML build succeeds; all emitted warnings are pre-existing in unrelated pages

The NPU workflow retains the proven CANN 9.1 / Torch 2.9 stack, `main` tracking, serialized execution, persistent ModelScope cache, corrupted-safetensors cleanup, 8B FP16 model, and 180-minute timeout.