### PR TITLE
[feature] 迁移 DeepSpeed 的 quick start 文档测试看护

### DIFF
--- a/.github/workflows/deepspeed-quick-start.yml
+++ b/.github/workflows/deepspeed-quick-start.yml
@@ -1,0 +1,34 @@
+# DeepSpeed quick start guard - thin trigger over quick-start-template.yml; the engine owns the monitor loop, cache I/O and result publishing.
+name: deepspeed-quick-start
+
+concurrency:
+  group: ${{ github.event_name == 'schedule' && 'deepspeed-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  cancel-in-progress: false
+
+on:
+  # Every 3 hours at minute 0, offset from peft (minute 30) to avoid NPU runner contention.
+  schedule:
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/deepspeed/**'
+      - 'tests/deepspeed/**'
+
+permissions:
+  contents: read
+
+jobs:
+  deepspeed-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      project: deepspeed
+      test_runner: '["linux-aarch64-a2-2"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      container_options: ''
+      timeout_minutes: 180
+      upstream_repo: deepspeedai/DeepSpeed
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/deepspeed/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/deepspeed/quick_start.md
+      test_command: python -m unittest tests.deepspeed.test_quick_start_ascend -v 2>&1

--- a/index.rst
+++ b/index.rst
@@ -139,7 +139,7 @@
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/deepspeed.png')"></div><h3 class="card-title">DeepSpeed</h3></div>
          <p class="card-desc">DeepSpeed is a deep learning optimization library that makes distributed training and inference easy, efficient, and effective. </p>
-         <div class="card-footer"><a href="https://github.com/deepspeedai/DeepSpeed">官方链接</a><span class="split">|</span><a href="https://www.deepspeed.ai/tutorials/accelerator-setup-guide/">文档中心</a><span class="split">|</span><a href="https://www.deepspeed.ai/tutorials/accelerator-setup-guide/#huawei-ascend-npu">昇腾教程</a></div>
+         <div class="card-footer"><a href="https://github.com/deepspeedai/DeepSpeed">官方链接</a><span class="split">|</span><a href="sources/deepspeed/quick_start.html">快速上手</a></div>
       </div>
 
       <!-- kernels -->
@@ -398,7 +398,7 @@
    :caption: 🏗️  基础设施与框架
 
    sources/accelerate/index.rst
-   sources/deepspeed/index.rst
+   sources/deepspeed/quick_start.md
    sources/kernels/index.rst
    sources/pytorch/index.rst
    sources/Ray/index.rst

--- a/sources/deepspeed/index.rst
+++ b/sources/deepspeed/index.rst
@@ -1,8 +1,0 @@
-DeepSpeed
-=========
-
-昇腾相关文档由 DeepSpeed 官方维护，请访问官方文档站：
-
-- GitHub：`DeepSpeed <https://github.com/deepspeedai/DeepSpeed>`_
-- 文档中心：`Accelerator Setup Guide <https://www.deepspeed.ai/tutorials/accelerator-setup-guide/>`_
-- 昇腾教程：`Huawei Ascend NPU <https://www.deepspeed.ai/tutorials/accelerator-setup-guide/#huawei-ascend-npu>`_

--- a/sources/deepspeed/quick_start.md
+++ b/sources/deepspeed/quick_start.md
@@ -1,0 +1,185 @@
+# DeepSpeed
+
+在昇腾 NPU 上安装 DeepSpeed，用 CIFAR10 图像分类跑通第一次训练，并理解 DeepSpeed 的工作流程。
+
+## 前置条件
+
+- **硬件**：Atlas 800T / 900 A2 训练服务器，搭载 Ascend 910B NPU。本文先单卡训练，再双卡分布式（需要 2 张卡）。
+- **软件**：已装好 CANN，以及与 CANN 匹配的 `torch` + `torch_npu`（`torch.npu.is_available() == True`）。参考[快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html)与 [Ascend PyTorch 安装文档](https://gitcode.com/Ascend/pytorch)。
+- **示例版本**：Python 3.12 · CANN 9.1.0 · torch 2.9.x · torch_npu 2.9.x · torchvision 0.24.x · deepspeed 0.19.x。
+
+## 安装 DeepSpeed
+
+**安装 DeepSpeed。** 通过 pip 安装。
+
+```shell #test id="install-deepspeed"
+pip install deepspeed
+python -c "import deepspeed; print('DeepSpeed', deepspeed.__version__)"
+```
+
+```shell #test-result id="install-deepspeed" fuzzy='...' fuzzy='xxx'
+...
+DeepSpeed xxx
+```
+
+**验证 DeepSpeed 已识别昇腾 NPU 加速器。** 输出 accelerator: npu 即接入成功。
+
+```shell #test id="verify-accelerator"
+python -c "from deepspeed.accelerator import get_accelerator; print('accelerator:', get_accelerator()._name)"
+```
+
+```shell #test-result id="verify-accelerator"
+accelerator: npu
+```
+
+## 安装 torchvision
+
+CIFAR10 数据集的加载依赖 torchvision。torchvision 与 torch 版本严格配套，固定版本以避免 pip 连带升级 torch。
+
+```shell #test id="install-torchvision"
+pip install "torchvision==0.24.*"
+python -c "import torchvision; print('torchvision', torchvision.__version__)"
+```
+
+```shell #test-result id="install-torchvision" fuzzy='...' fuzzy='xxx'
+...
+torchvision xxx
+```
+
+## 编写训练脚本
+
+下面这段 CIFAR10 训练脚本分 4 个模块，展示了 DeepSpeed 的完整工作流程。先把脚本写入 train_cifar10.py（deepspeed 启动器需要脚本文件路径），CIFAR10 数据集会在首次运行时自动下载。
+
+```shell #test-setup id="write-script"
+cat > train_cifar10.py <<'PY'
+import os
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torchvision
+from torchvision import transforms
+import deepspeed
+
+MICRO_BATCH = 8
+
+# ===== 模块 1：准备数据 =====
+# CIFAR10 数据集首次运行时自动下载：从 ModelScope 镜像获取并解压。
+data_dir = Path('./data')
+if not (data_dir / 'cifar-10-batches-py').exists():
+    data_dir.mkdir(parents=True, exist_ok=True)
+    archive = data_dir / 'cifar-10-batches-py.zip'
+    urllib.request.urlretrieve(
+        'https://modelscope.cn/api/v1/datasets/studyhard1/cifar10-dataset/repo?Revision=master&FilePath=cifar-10-batches-py.zip',
+        archive)
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(data_dir)
+transform = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+    transforms.ConvertImageDtype(torch.bfloat16),
+])
+trainset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=transform)
+# 每个 rank 独立从 DataLoader 取 micro batch。
+trainloader = torch.utils.data.DataLoader(trainset, batch_size=MICRO_BATCH, shuffle=True)
+
+# ===== 模块 2：定义模型 =====
+# 一个用于图像分类的小型 CNN。DeepSpeed 兼容任意 PyTorch 模型，无需修改模型代码。
+class Net(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(torch.relu(self.conv1(x)))
+        x = self.pool(torch.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = torch.relu(self.fc1(x))
+        x = torch.relu(self.fc2(x))
+        return self.fc3(x)
+
+# ===== 模块 3：配置 DeepSpeed 并初始化引擎 =====
+# 全局 batch = 每卡 batch × 卡数；WORLD_SIZE 由 deepspeed 启动器注入，直接 python 运行时为 1。
+world_size = int(os.environ.get('WORLD_SIZE', 1))
+# deepspeed.initialize() 是 DeepSpeed 的入口，优化器、ZeRO 显存优化和 BF16 混合精度在此注入，返回封装后的模型引擎。
+ds_config = {
+    'train_batch_size': MICRO_BATCH * world_size,
+    'optimizer': {
+        'type': 'Adam',
+        'params': {'lr': 0.001},
+    },
+    'zero_optimization': {'stage': 1},
+    'bf16': {'enabled': True},
+}
+model = Net()
+model_engine, optimizer, _, _ = deepspeed.initialize(
+    model=model, model_parameters=model.parameters(), config=ds_config)
+
+# ===== 模块 4：训练循环 =====
+# model_engine.backward() 和 model_engine.step() 替换了原生 API，DeepSpeed 在此接管梯度计算与参数更新。
+# 多卡时仅 rank 0 打印，避免输出交错。
+criterion = nn.CrossEntropyLoss()
+for epoch in range(1):
+    running_loss = 0.0
+    for i, data in enumerate(trainloader):
+        inputs, labels = data[0].to(model_engine.device), data[1].to(model_engine.device)
+        outputs = model_engine(inputs)
+        loss = criterion(outputs, labels)
+        model_engine.backward(loss)
+        model_engine.step()
+        running_loss += loss.item()
+        if i % 100 == 99:
+            if model_engine.global_rank == 0:
+                print(f'[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 100:.3f}')
+            running_loss = 0.0
+if model_engine.global_rank == 0:
+    print('Finished Training')
+PY
+```
+
+## 单卡训练
+
+**启动训练。** deepspeed 启动器拉起 1 个训练进程。
+
+```shell #test id="run-train"
+deepspeed --num_gpus 1 train_cifar10.py
+```
+
+**验证训练结果。** 末尾输出包含 Finished Training 即训练成功。
+
+```shell #test-result id="run-train" fuzzy='...'
+...
+Finished Training
+...
+```
+
+## 多卡分布式训练
+
+DeepSpeed 的核心价值在分布式：同一份脚本不改一行代码，只把 `--num_gpus` 改成 2。DeepSpeed 会自动：
+
+- 拉起 2 个训练进程，注入 `RANK` / `WORLD_SIZE` / `LOCAL_RANK`；
+- 建立 HCCL 通信后端，初始化分布式环境；
+- 全局 batch（每卡 8 × 2 卡 = 16）自动调度，ZeRO-1 把优化器状态分片到 2 卡。
+
+```shell #test id="run-train-2card"
+deepspeed --num_gpus 2 train_cifar10.py
+```
+
+**验证训练结果。** 数据集已在单卡阶段下载完毕，两个 rank 直接开始训练，输出经 rank 0 打印。
+
+```shell #test-result id="run-train-2card" fuzzy='...'
+...
+Finished Training
+...
+```
+
+## 更多用法
+
+更多用法见 DeepSpeedExamples：https://github.com/deepspeedai/DeepSpeedExamples

--- a/tests/deepspeed/__init__.py
+++ b/tests/deepspeed/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent ``__init__.py``
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/deepspeed/__init__.py -> parents[0]=tests/deepspeed,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/deepspeed/test_quick_start_ascend.py
+++ b/tests/deepspeed/test_quick_start_ascend.py
@@ -1,0 +1,129 @@
+"""DeepSpeed quick-start documentation test.
+Doc under test: sources/deepspeed/quick_start.md.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+
+
+def _is_truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+def _ensure_torch_npu():
+    """Reuse the image's torch stack when torch/torch_npu match 2.9.0;
+    reinstall from cluster + Ascend index only on probe failure."""
+    _PROBE_SCRIPT = (
+        'import torch, torch_npu\n'
+        "raise SystemExit(0 if "
+        "torch.__version__.startswith('2.9.0') "
+        "and torch_npu.__version__.startswith('2.9.0') "
+        "else 1)"
+    )
+    probe = subprocess.run(
+        [sys.executable, '-c', _PROBE_SCRIPT],
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        versions = subprocess.run(
+            [sys.executable, '-c',
+             'import torch, torch_npu; print(torch.__version__, torch_npu.__version__)'],
+            capture_output=True, text=True, check=True,
+        )
+        print(f'setup: reusing image torch stack ({versions.stdout.strip()})')
+        return
+    print('setup: installing torch==2.9.0 torch_npu==2.9.0.post2')
+    subprocess.run(
+        [
+            sys.executable, '-m', 'pip', 'install',
+            '--index-url', 'http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple',
+            '--extra-index-url', 'https://repo.huaweicloud.com/ascend/repos/pypi',
+            'torch==2.9.0', 'torch_npu==2.9.0.post2',
+        ],
+        check=True,
+    )
+    subprocess.run([sys.executable, '-c', _PROBE_SCRIPT], check=True)
+    print('setup: installed torch==2.9.0 torch_npu==2.9.0.post2')
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    DEFAULT_COMMAND_TIMEOUT = 1800
+    USER_AGENT = 'cosdt-ci-test/quick-start'
+    _CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+
+    def pre_process(self) -> str:
+        """Use the repo-bundled doc instead of MONITORED_DOC_URL so the
+        test always runs the version that ships with the code."""
+        doc = Path(__file__).resolve().parent.parent.parent / 'sources' / 'deepspeed' / 'quick_start.md'
+        return doc.read_text(encoding='utf-8')
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """One-time CI prep: CANN env (fenced blocks are fresh subprocesses,
+        so it must be injected here), 2-card visibility, cwd, MPI."""
+        path_dirs = '/usr/local/sbin:/usr/local/bin'
+        current_path = os.environ.get('PATH', '')
+        if path_dirs not in current_path:
+            os.environ['PATH'] = f'{path_dirs}:{current_path}'
+
+        if os.path.isfile(cls._CANN_SET_ENV):
+            merged = subprocess.run(
+                ['bash', '-c', f'source {cls._CANN_SET_ENV} >/dev/null 2>&1; env'],
+                capture_output=True, text=True, check=True,
+            )
+            for line in merged.stdout.splitlines():
+                if '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                os.environ.setdefault(key, value)
+            print('setup: sourced CANN env from set_env.sh')
+        else:
+            print(
+                f'setup: skipping CANN env source ({cls._CANN_SET_ENV} not present)'
+            )
+
+        os.environ['ASCEND_RT_VISIBLE_DEVICES'] = '0,1'
+        print('setup: pinned ASCEND_RT_VISIBLE_DEVICES=0,1')
+
+        project_root = Path(__file__).resolve().parent.parent.parent / 'sources' / 'deepspeed'
+        os.chdir(str(project_root))
+        print(f'setup: cwd -> {project_root}')
+
+        subprocess.run(['apt-get', 'update'], check=True)
+        subprocess.run(['apt-get', 'install', '-y', 'libopenmpi-dev'], check=True)
+        subprocess.run(
+            [sys.executable, '-m', 'pip', 'install', 'mpi4py'],
+            check=True,
+        )
+        print('setup: installed MPI (libopenmpi-dev + mpi4py)')
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if _e2e_enabled():
+            cls.prepare_environment()
+            _ensure_torch_npu()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end tests require NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 总结

为 DeepSpeed 接入 quick start 文档测试看护。

看护内容为 `sources/deepspeed/quick_start.md`：在昇腾 NPU 上安装 DeepSpeed，验证 NPU 加速器识别，然后分别以单卡（`--num_gpus 1`）和双卡（`--num_gpus 2`）模式跑 CIFAR10 图像分类训练，数据集经 ModelScope 下载。

## 变更文件

- 新增：`sources/deepspeed/quick_start.md`（被看护文档，替换外链占位页）、`.github/workflows/deepspeed-quick-start.yml`、`tests/deepspeed/`
- 删除：`sources/deepspeed/index.rst`
- 调整：首页 `index.rst` toctree 直接收录 `sources/deepspeed/quick_start.md`，DeepSpeed 卡片「快速上手」指向其构建产物 `sources/deepspeed/quick_start.html`

## 验证

- 本地和github action测试均全绿通过