### PR TITLE
[feature] 迁移 LMCache Quick Start 并接入看护

### DIFF
--- a/.github/workflows/lmcache-quick-start.yml
+++ b/.github/workflows/lmcache-quick-start.yml
@@ -1,0 +1,66 @@
+# lmcache quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+
+name: lmcache-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'lmcache-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Offset from peft's '30 */3 * * *' and llama_cpp's '45 */3 * * *'.
+    - cron: '25 */3 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/lmcache/**'
+      - 'tests/lmcache/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lmcache-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-lmcache-*), artifacts
+      # (lmcache-quick-start-<run_id>) and the test working dir
+      # (workflows/tests/lmcache).
+      project: lmcache
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # Do not add a container bind-mount for /root/.cache: the runner
+      # NFS already persists that tree. Cold path compiles LMCache-Ascend
+      # c_ops and downloads Qwen2.5-0.5B-Instruct from Hugging Face Hub.
+      timeout_minutes: 180
+      upstream_repo: LMCache/LMCache-Ascend
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/lmcache/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/lmcache/quick_start.md
+      # cwd is the repo root inside the `workflows` checkout (matches
+      # engine template's `working-directory: workflows`); env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep lives in the test subclass's
+      # prepare_environment hook.
+      test_command: python -m unittest tests.lmcache.test_quick_start_ascend -v 2>&1

--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,10 @@ language = 'zh_CN'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
-                    '.github', 'tests']
+                    '.github', 'tests',
+                    # Included into sources/lmcache/index.rst; excluding
+                    # the file itself avoids a nested sidebar「快速开始」.
+                    'sources/lmcache/quick_start.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -250,6 +250,13 @@
          <div class="card-footer"><a href="https://github.com/ggerganov/llama.cpp">官方链接</a><span class="split">|</span><a href="sources/llama_cpp/install.html">安装指南</a><span class="split">|</span><a href="sources/llama_cpp/quick_start.html">快速上手</a></div>
       </div>
 
+      <!-- LMCache -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/vllm-ascend.png')"></div><h3 class="card-title">LMCache</h3></div>
+         <p class="card-desc">昇腾上的 KV 缓存插件，把 vLLM 的 KV 卸载到本机 CPU。</p>
+         <div class="card-footer"><a href="https://github.com/LMCache/LMCache-Ascend">官方链接</a><span class="split">|</span><a href="https://docs.lmcache.ai/">文档中心</a><span class="split">|</span><a href="sources/lmcache/index.html">快速上手</a></div>
+      </div>
+
       <!-- LMDeploy：官方文档站已含昇腾说明，外链跳转，不再本地编译 -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/lm-deploy.png')"></div><h3 class="card-title">lmdeploy</h3></div>
@@ -426,6 +433,7 @@
    :caption: 🚀 推理与服务
 
    sources/llama_cpp/index.rst
+   sources/lmcache/index.rst
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst
    sources/sentence_transformers/index.rst

--- a/sources/lmcache/index.rst
+++ b/sources/lmcache/index.rst
@@ -1,0 +1,2 @@
+.. include:: quick_start.md
+   :parser: myst_parser.sphinx_

--- a/sources/lmcache/quick_start.md
+++ b/sources/lmcache/quick_start.md
@@ -289,7 +289,6 @@ python -c "import lmcache, lmcache_ascend, torch, torch_npu; from lmcache_ascend
 输出结果如下：
 
 ```shell #test-result id="install-lmcache-ascend" load="lmcache_ver>>ver"
-...
 patched_ok True
 ...
 lmcache <ver>

--- a/sources/lmcache/quick_start.md
+++ b/sources/lmcache/quick_start.md
@@ -6,7 +6,7 @@
 
 ### 硬件
 
-Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。编译 LMCache-Ascend 时把 `SOC_VERSION` 设成 `Ascend910B4`。
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。编译会读 `npu-smi` 得到芯片型号，A2 上常见 `Ascend910B3` 或 `Ascend910B4`；没有 `npu-smi` 时再设 `SOC_VERSION`。
 
 ### 软件
 
@@ -282,7 +282,7 @@ PY
 ```shell #test id="install-lmcache-ascend"
 python patch_lmcache_ascend.py
 rm -rf LMCache-Ascend/build
-SOC_VERSION=Ascend910B4 python -m pip install -v --no-build-isolation -e ./LMCache-Ascend
+python -m pip install -v --no-build-isolation -e ./LMCache-Ascend
 python -c "import lmcache, lmcache_ascend, torch, torch_npu; from lmcache_ascend import _build_info as b; import lmcache_ascend.c_ops; print('lmcache', lmcache.__version__); print('soc', b.__soc_version__); print('c_ops_ok', True); print('npu_available', torch.npu.is_available())"
 ```
 
@@ -293,12 +293,12 @@ python -c "import lmcache, lmcache_ascend, torch, torch_npu; from lmcache_ascend
 patched_ok True
 ...
 lmcache <ver>
-soc Ascend910B4
+soc Ascend910B...
 c_ops_ok True
 npu_available True
 ```
 
-`soc` 必须是编译时设的 `Ascend910B4`。缺 `numaif.h` 时先回到第 3 节。
+`soc` 应和本机 `npu-smi info -t board` 的 Chip Name 一致。缺 `numaif.h` 时先回到第 3 节。
 
 ## 7. 用离线 LLM 做一次 KV 卸载
 

--- a/sources/lmcache/quick_start.md
+++ b/sources/lmcache/quick_start.md
@@ -1,0 +1,424 @@
+# LMCache
+
+在单卡昇腾上安装 vLLM-Ascend，编译 [LMCache-Ascend](https://github.com/LMCache/LMCache-Ascend)，再用 `vllm.LLM` 运行 KV 卸载连接器。主仓 [LMCache/LMCache](https://github.com/LMCache/LMCache) 没有昇腾实现，昇腾侧在同组织的 **LMCache-Ascend**。
+
+## 前置条件
+
+### 硬件
+
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。编译 LMCache-Ascend 时把 `SOC_VERSION` 设成 `Ascend910B4`。
+
+### 软件
+
+
+| 类别          | 要求                                                                              |
+| ----------- | ------------------------------------------------------------------------------- |
+| CANN        | toolkit + 驱动固件已安装，并可 `source set_env.sh`                                        |
+| ATB         | Ascend Transformer Boost。vLLM EngineCore 子进程要加载 `libatb.so`                     |
+| Python      | 3.12                                                                            |
+| 编译依赖        | `cmake`、`ninja`、`libnuma-dev`，见下文安装                                             |
+| vLLM-Ascend | `vllm` / `vllm-ascend` 均为 `0.23.0`，见下文安装                                        |
+| LMCache     | PyPI `lmcache` 的版本号等于 Release tag 去掉开头的 `v`，再编译 LMCache-Ascend                  |
+| 模型          | [Qwen/Qwen2.5-0.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct) |
+
+
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 准备好 CANN 与驱动。推荐配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+## 1. 加载 CANN 环境
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/latest/atb/set_env.sh
+export PATH=/usr/local/sbin:/usr/sbin:$PATH
+```
+
+
+
+## 2. 检查环境是否就绪
+
+### 2.1 确认 NPU 在线
+
+```shell
+npu-smi info
+```
+
+如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。 
+
+### 2.2 确认工具可用
+
+下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
+
+```shell #test id="check-tools"
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi >/dev/null
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-tools"
+Python 3.12...
+```
+
+
+
+## 3. 安装编译依赖
+
+LMCache-Ascend 的 C++ 插件需要 `cmake`、`ninja` 和 NUMA 头文件。没有就装上。
+
+<!--
+```shell #test-setup
+if getent hosts cache-service.nginx-pypi-cache.svc.cluster.local >/dev/null 2>&1 \
+    && [ -f /etc/apt/sources.list ]; then
+  sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+fi
+```
+-->
+
+```shell #test id="install-system-prereqs"
+if ! command -v cmake >/dev/null 2>&1 \
+    || ! command -v ninja >/dev/null 2>&1 \
+    || [ ! -f /usr/include/numaif.h ]; then
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y cmake ninja-build libnuma-dev
+fi
+cmake --version
+```
+
+输出结果如下：
+
+```shell #test-result id="install-system-prereqs"
+...
+cmake version 3...
+```
+
+## 4. 安装 vLLM-Ascend
+
+分三步安装，不要合成一次 `pip install`。最后一步必须 `--force-reinstall --no-deps`，否则会留下社区 CUDA 版 Triton，第一次推理报错。
+
+```shell #test id="install-vllm"
+python -m pip install --retries 3 vllm==0.23.0
+python -m pip install \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi/variant \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  vllm-ascend==0.23.0
+python -m pip install --force-reinstall --no-deps \
+  --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+  triton-ascend==3.2.2
+python -c "import importlib.metadata as m
+for n in ['torch', 'torch-npu', 'vllm', 'vllm-ascend']:
+    print(n, m.version(n))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-vllm"
+...
+torch 2.10.0...
+torch-npu 2.10.0.post4
+vllm 0.23.0...
+vllm-ascend 0.23.0
+```
+
+
+
+## 5. 安装 lmcache
+
+将 `<ver>` 换成目标 tag 去掉开头的 `v`。撰写时最新 Release 是 `v0.4.4`，对应 `lmcache==0.4.4`。
+
+<!--
+```shell #test-setup store="lmcache_ver"
+echo "${UPSTREAM_REF#v}"
+```
+-->
+
+```shell #test id="install-lmcache" load="lmcache_ver>>ver"
+NO_CUDA_EXT=1 python -m pip install --no-build-isolation lmcache==<ver> --no-deps
+python -m pip install \
+  aiofile aiofiles blake3 aiohttp msgspec numpy psutil pyyaml pyzmq \
+  redis safetensors sortedcontainers transformers huggingface_hub
+python -c "import importlib.metadata as m; print('lmcache', m.version('lmcache'))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-lmcache" load="lmcache_ver>>ver"
+...
+lmcache <ver>
+```
+
+
+
+## 6. 克隆并编译 LMCache-Ascend
+
+克隆 release tag（`<ref>` 可改为例如 `v0.4.4`）。主仓在 GitHub；子模块和主仓分开拉。若 `LMCache-Ascend/csrc/hixl/CMakeLists.txt` 已经在，就跳过 clone。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+```shell #test id="clone-lmcache-ascend" load="upstream_ref>>ref"
+if [ ! -f LMCache-Ascend/csrc/hixl/CMakeLists.txt ]; then
+  rm -rf LMCache-Ascend
+  for _ in 1 2 3; do
+    GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
+      git clone --depth 1 --branch <ref> https://github.com/LMCache/LMCache-Ascend.git LMCache-Ascend && break
+    rm -rf LMCache-Ascend
+    sleep 5
+  done
+fi
+GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 \
+  git -C LMCache-Ascend submodule update --init --recursive
+git -C LMCache-Ascend describe --tags --exact-match
+```
+
+输出结果如下：
+
+```shell #test-result id="clone-lmcache-ascend" load="upstream_ref>>ref"
+...
+<ref>
+```
+
+最新 Release `v0.4.4` 在 CANN 9.1 上编 HIXL 会缺 `runtime/rt_external_device.h`，在 vLLM 0.23 上会拒两参数 KV connector；克隆后先跑下面的补丁再编译。源码里已经有对应内容时脚本会跳过。
+
+保存为 `patch_lmcache_ascend.py`：
+
+```python
+import re
+from pathlib import Path
+
+cmake = Path("LMCache-Ascend/csrc/hixl/CMakeLists.txt")
+text = cmake.read_text()
+runtime = "${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc/runtime"
+pkg = "${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc"
+if not re.search(r"/pkg_inc\s*$", text, re.M):
+    if runtime not in text:
+        raise SystemExit("hixl cmake include line not found")
+    cmake.write_text(text.replace(runtime, runtime + "\n    " + pkg, 1))
+
+conn = Path(
+    "LMCache-Ascend/lmcache_ascend/integration/vllm/"
+    "lmcache_ascend_connector_v1.py"
+)
+text = conn.read_text()
+if "kv_cache_config" not in text:
+    old_init = (
+        "class LMCacheAscendConnectorV1Dynamic(LMCacheConnectorV1Dynamic):\n"
+        "    def __init__(self, vllm_config: \"VllmConfig\", role: KVConnectorRole) -> None:\n"
+        "        super().__init__(vllm_config=vllm_config, role=role)\n"
+    )
+    new_init = (
+        "class LMCacheAscendConnectorV1Dynamic(LMCacheConnectorV1Dynamic):\n"
+        "    def __init__(\n"
+        "        self,\n"
+        "        vllm_config: \"VllmConfig\",\n"
+        "        role: KVConnectorRole,\n"
+        "        kv_cache_config=None,\n"
+        "    ) -> None:\n"
+        "        super().__init__(\n"
+        "            vllm_config=vllm_config,\n"
+        "            role=role,\n"
+        "            kv_cache_config=kv_cache_config,\n"
+        "        )\n"
+    )
+    if old_init not in text:
+        raise SystemExit("connector __init__ not found")
+    conn.write_text(text.replace(old_init, new_init, 1))
+print("patched_ok", True)
+```
+
+<!--
+```shell #test-setup
+cat > patch_lmcache_ascend.py <<'PY'
+import re
+from pathlib import Path
+
+cmake = Path("LMCache-Ascend/csrc/hixl/CMakeLists.txt")
+text = cmake.read_text()
+runtime = "${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc/runtime"
+pkg = "${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc"
+if not re.search(r"/pkg_inc\s*$", text, re.M):
+    if runtime not in text:
+        raise SystemExit("hixl cmake include line not found")
+    cmake.write_text(text.replace(runtime, runtime + "\n    " + pkg, 1))
+
+conn = Path(
+    "LMCache-Ascend/lmcache_ascend/integration/vllm/"
+    "lmcache_ascend_connector_v1.py"
+)
+text = conn.read_text()
+if "kv_cache_config" not in text:
+    old_init = (
+        "class LMCacheAscendConnectorV1Dynamic(LMCacheConnectorV1Dynamic):\n"
+        "    def __init__(self, vllm_config: \"VllmConfig\", role: KVConnectorRole) -> None:\n"
+        "        super().__init__(vllm_config=vllm_config, role=role)\n"
+    )
+    new_init = (
+        "class LMCacheAscendConnectorV1Dynamic(LMCacheConnectorV1Dynamic):\n"
+        "    def __init__(\n"
+        "        self,\n"
+        "        vllm_config: \"VllmConfig\",\n"
+        "        role: KVConnectorRole,\n"
+        "        kv_cache_config=None,\n"
+        "    ) -> None:\n"
+        "        super().__init__(\n"
+        "            vllm_config=vllm_config,\n"
+        "            role=role,\n"
+        "            kv_cache_config=kv_cache_config,\n"
+        "        )\n"
+    )
+    if old_init not in text:
+        raise SystemExit("connector __init__ not found")
+    conn.write_text(text.replace(old_init, new_init, 1))
+print("patched_ok", True)
+PY
+```
+-->
+
+编译前删掉 `LMCache-Ascend/build`。CANN 把昇腾核目标链接进 `.o` 时会原地改文件，留着上次的产物再编，链接器会报 `unknown file type`。用 `-e ./LMCache-Ascend` 安装，不要 `cd` 进克隆目录。
+
+```shell #test id="install-lmcache-ascend"
+python patch_lmcache_ascend.py
+rm -rf LMCache-Ascend/build
+SOC_VERSION=Ascend910B4 python -m pip install -v --no-build-isolation -e ./LMCache-Ascend
+python -c "import lmcache, lmcache_ascend, torch, torch_npu; from lmcache_ascend import _build_info as b; import lmcache_ascend.c_ops; print('lmcache', lmcache.__version__); print('soc', b.__soc_version__); print('c_ops_ok', True); print('npu_available', torch.npu.is_available())"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-lmcache-ascend" load="lmcache_ver>>ver"
+...
+patched_ok True
+...
+lmcache <ver>
+soc Ascend910B4
+c_ops_ok True
+npu_available True
+```
+
+`soc` 必须是编译时设的 `Ascend910B4`。缺 `numaif.h` 时先回到第 3 节。
+
+## 7. 用离线 LLM 做一次 KV 卸载
+
+第一次跑通不要开 `vllm serve`，服务进程不会自己退出。下面用和上游 `examples/offload.py` 同一套连接器，换成 Hugging Face 上的 Qwen2.5-0.5B-Instruct，并把 `max_model_len` 收到 512、`gpu_memory_utilization` 收到 0.4，方便单卡几分钟内结束。
+
+`VLLM_WORKER_MULTIPROC_METHOD=spawn` 避免父进程初始化过 NPU 之后子进程再 `fork`。`PYTHONHASHSEED=0` 让 LMCache 跨进程的 token hash 稳定。`VLLM_LOGGING_LEVEL=INFO` 让昇腾插件和 LMCache 引擎的设备日志打出来。脚本必须先 `import vllm`，再 `import lmcache_ascend`，后者只在检测到 vLLM 已经加载时才会把设备检测换成 NPU 版。末尾 `2>&1` 把打在 stderr 的设备日志并进标准输出。
+
+保存为 `offload_qs.py`：
+
+```python
+import os
+
+from huggingface_hub import snapshot_download
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+import lmcache_ascend
+import torch
+import torch_npu
+from lmcache.integration.vllm.utils import ENGINE_NAME
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+
+
+def main():
+    os.environ.setdefault("LMCACHE_CHUNK_SIZE", "256")
+    os.environ.setdefault("LMCACHE_LOCAL_CPU", "True")
+    os.environ.setdefault("LMCACHE_MAX_LOCAL_CPU_SIZE", "2")
+
+    model = snapshot_download("Qwen/Qwen2.5-0.5B-Instruct")
+    ktc = KVTransferConfig(
+        kv_connector="LMCacheAscendConnectorV1Dynamic",
+        kv_role="kv_both",
+        kv_connector_module_path=(
+            "lmcache_ascend.integration.vllm.lmcache_ascend_connector_v1"
+        ),
+    )
+    llm = LLM(
+        model=model,
+        enforce_eager=True,
+        kv_transfer_config=ktc,
+        max_model_len=512,
+        gpu_memory_utilization=0.4,
+        trust_remote_code=True,
+    )
+    params = SamplingParams(temperature=0, top_p=0.95, max_tokens=8)
+    llm.generate(["Hello, my name is", "Tell me a short story"], params)
+    print("current_device", f"npu:{torch.npu.current_device()}")
+    print("npu_available", torch.npu.is_available())
+    print("workload_ok", True)
+    LMCacheEngineBuilder.destroy(ENGINE_NAME)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+<!--
+```shell #test-setup
+cat > offload_qs.py <<'PY'
+import os
+
+from huggingface_hub import snapshot_download
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+import lmcache_ascend
+import torch
+import torch_npu
+from lmcache.integration.vllm.utils import ENGINE_NAME
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+
+
+def main():
+    os.environ.setdefault("LMCACHE_CHUNK_SIZE", "256")
+    os.environ.setdefault("LMCACHE_LOCAL_CPU", "True")
+    os.environ.setdefault("LMCACHE_MAX_LOCAL_CPU_SIZE", "2")
+
+    model = snapshot_download("Qwen/Qwen2.5-0.5B-Instruct")
+    ktc = KVTransferConfig(
+        kv_connector="LMCacheAscendConnectorV1Dynamic",
+        kv_role="kv_both",
+        kv_connector_module_path=(
+            "lmcache_ascend.integration.vllm.lmcache_ascend_connector_v1"
+        ),
+    )
+    llm = LLM(
+        model=model,
+        enforce_eager=True,
+        kv_transfer_config=ktc,
+        max_model_len=512,
+        gpu_memory_utilization=0.4,
+        trust_remote_code=True,
+    )
+    params = SamplingParams(temperature=0, top_p=0.95, max_tokens=8)
+    llm.generate(["Hello, my name is", "Tell me a short story"], params)
+    print("current_device", f"npu:{torch.npu.current_device()}")
+    print("npu_available", torch.npu.is_available())
+    print("workload_ok", True)
+    LMCacheEngineBuilder.destroy(ENGINE_NAME)
+
+
+if __name__ == "__main__":
+    main()
+PY
+```
+-->
+
+```shell #test id="offload"
+export PYTHONHASHSEED=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_LOGGING_LEVEL=INFO
+python offload_qs.py 2>&1
+```
+
+输出结果如下：
+
+```shell #test-result id="offload"
+...Platform plugin ascend is activated...Using NPU for LMCache engine...
+current_device npu:0
+npu_available True
+workload_ok True
+...
+```
+
+生成文字每次可能不同。`current_device npu:0` 和 `Using NPU for LMCache engine` 才是这一次上了昇腾、并且 LMCache 引擎也在 NPU 上的证据。结束时 ZMQ 可能打一条 `Assertion failed: pfd.revents`，只要退出码是 0、上面几行都在，可以忽略。

--- a/tests/lmcache/__init__.py
+++ b/tests/lmcache/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent ``__init__.py``
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/lmcache/__init__.py -> parents[0]=tests/lmcache,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/lmcache/test_quick_start_ascend.py
+++ b/tests/lmcache/test_quick_start_ascend.py
@@ -1,0 +1,135 @@
+"""Quick-start test: doc under test is ``sources/lmcache/quick_start.md``.
+
+Run: ``python -m unittest tests.lmcache.test_quick_start_ascend -v 2>&1``
+
+Env (injected by the engine ``quick-start-template.yml``, triggered by
+``lmcache-quick-start.yml``): ``MONITORED_DOC_URL``, ``UPSTREAM_REF``,
+``NPU_READY=true`` (otherwise the class is skipped).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    ensure_safetensors,
+    purge_huggingface_corrupt,
+    report_huggingface_state,
+    resolve_huggingface_cache,
+)
+
+_CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+_ATB_SET_ENV = '/usr/local/Ascend/nnal/atb/latest/atb/set_env.sh'
+
+
+def _is_truthy(value: str | None) -> bool:
+    """``'true'`` -> True (case-insensitive); anything else (including unset) -> False."""
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    """Return True when ``NPU_READY=true`` is set, releasing the skip."""
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    """End-to-end test: fetch doc -> validate contract -> run ``#test-setup``
+    / ``#test`` in order -> compare against ``#test-result``."""
+
+    DEFAULT_COMMAND_TIMEOUT = 5400
+    USER_AGENT = 'ascend-docs/quick-start'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'ERR99999',
+        'HostRegisterError',
+        'libatb.so',
+        'Unsupported device platform for LMCache engine',
+    )
+
+    _MODEL_ID = 'Qwen/Qwen2.5-0.5B-Instruct'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN / ATB once so later ``bash -c`` blocks inherit them.
+
+        Class-level setup: run once per test class, triggered by
+        ``setUpClass``. Each labeled fence is a new subprocess, so a
+        ``source set_env.sh`` block in the document does not persist.
+
+        Merge is overwrite, not ``setdefault``: the container image may
+        already ship ``LD_LIBRARY_PATH``, which would otherwise hide the
+        CANN increment from ``set_env.sh``.
+        """
+        venv_prefix = ''
+        virtual_env = os.environ.get('VIRTUAL_ENV')
+        if virtual_env:
+            venv_prefix = str(Path(virtual_env) / 'bin')
+
+        missing = [p for p in (_CANN_SET_ENV, _ATB_SET_ENV) if not os.path.isfile(p)]
+        if missing:
+            raise RuntimeError(
+                'required Ascend env scripts missing: ' + ', '.join(missing)
+            )
+        sourced = ' && '.join(
+            f'source {shlex.quote(script)} >/dev/null 2>&1'
+            for script in (_CANN_SET_ENV, _ATB_SET_ENV)
+        )
+        merged = subprocess.run(
+            ['bash', '-c', f'set +u; {sourced}; env'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            os.environ[key] = value
+        extras = []
+        for extra in ('/usr/local/sbin', '/usr/local/bin', '/usr/sbin'):
+            parts = os.environ.get('PATH', '').split(':')
+            if extra not in parts:
+                extras.append(extra)
+        if extras:
+            os.environ['PATH'] = os.environ.get('PATH', '') + ':' + ':'.join(extras)
+        if venv_prefix:
+            current = os.environ.get('PATH', '')
+            if not current.startswith(venv_prefix + ':'):
+                os.environ['PATH'] = f'{venv_prefix}:{current}'
+        os.environ['PYTHONNOUSERSITE'] = '1'
+        print('setup: sourced CANN and ATB env')
+
+        ensure_safetensors()
+        report_huggingface_state(cls._MODEL_ID)
+        purge_huggingface_corrupt(resolve_huggingface_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing when
+        ``NPU_READY`` is unset.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Run the full pre_process -> parse -> execute -> post_process flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- 把 `LMCache/LMCache-Ascend` 的昇腾 Quick Start 迁到 `Ascend/docs`：用户文档、测试子类、薄触发器、首页卡片和 toctree 同一 PR。主仓 `LMCache/LMCache` 没有昇腾实现，monitor 的 `upstream_repo` 是 `LMCache/LMCache-Ascend`。
- 可见命令直连 GitHub 与 Hugging Face；模型走默认 Hub 缓存 `Qwen/Qwen2.5-0.5B-Instruct`。薄触发器不传 `container_options` / `--volume`，镜像钉 `cann:9.1.0-910b-ubuntu22.04-py3.12`，runner 单卡 `linux-aarch64-a2-1`。
- vLLM 按统一三步 pip：`vllm==0.23.0` → `vllm-ascend==0.23.0` → `--force-reinstall --no-deps triton-ascend==3.2.2`。补丁脚本和离线卸载脚本拆成无标签 `.py` + 隐藏 `#test-setup` `cat` + 可见 `python path.py`。工作负载 `#test-result` 含设备锚点 `Platform plugin ascend is activated` / `Using NPU for LMCache engine` / `current_device npu:0`。

## 选型（不进用户正文）

- 看护钉最新 Release `v0.4.4`，不跟 `main`。这个 tag 在 CANN 9.1 上编 HIXL 缺 `pkg_inc` 这一层 include（[PR 288](https://github.com/LMCache/LMCache-Ascend/pull/288) 已合进 main，尚未进 Release）；子类 `LMCacheAscendConnectorV1Dynamic` 到 main 仍是两参数构造，vLLM 0.23 工厂会因缺少 `kv_cache_config` 直接 `ValueError`。因此克隆后必须先跑本地补丁再编译；源码已有对应内容时脚本跳过。
- 引擎规定 HTML 注释里只能放 `#test-setup`，不能把 `#test` 藏进去。可见无标签 Python 围栏给人复制保存，CI 靠注释里的 `cat` 落盘，再由可见 `#test` 真正执行 `python patch_lmcache_ascend.py`。
- 不改共享引擎 `quick-start-template.yml` / `tests/doc_test/`。

## Test plan

- [x] `actionlint` 薄触发器
- [x] `py_compile` 测试子类
- [x] 解析：7 个 `#test`（`check-tools` / `install-system-prereqs` / `install-vllm` / `install-lmcache` / `clone-lmcache-ascend` / `install-lmcache-ascend` / `offload`），5 个隐藏 `#test-setup`；注释里没有 `#test` / `#test-result`
- [x] 可见正文无 `cosdt-ci-test` / `/root/.cache` / `modelscope` / `gh-proxy` / `python - <<`
- [x] `patch_lmcache_ascend.py` 与 `offload_qs.py` 的可见围栏与隐藏 `cat` 字节一致
- [ ] 香港 A2 冷缓存 `workflow_dispatch`：clone + 编译 HIXL + Hub 下载 + 设备锚点
- [ ] 香港 A2 热缓存：`/root/.cache/huggingface/hub` 已有模型后重跑卸载段

coder 出口网络和香港 A2 runner 不同，GitHub clone / Hugging Face 下载没有在 coder 上当作 e2e 证据。合入默认分支前对新 workflow 做 `workflow_dispatch` 会 404；合入后在香港 A2 上补冷/热两次。