### PR TITLE
[feature]支持ComfyUI的quick start文档测试看护

### DIFF
--- a/.github/workflows/comfyui-quick-start.yml
+++ b/.github/workflows/comfyui-quick-start.yml
@@ -1,0 +1,87 @@
+# ComfyUI quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+# this file only declares what varies per project: schedule,
+# concurrency, runner, container image, upstream repo, monitored doc
+# and the test entry command. The guard loop, cache I/O, state relay
+# and publishing all live in the engine. See the engine's
+# `workflow_call.inputs` block for the full input contract.
+#
+# Engine-fixed behaviours this trigger relies on (declared in the
+# engine, NOT here):
+#   * cache key prefix: monitor-state-comfyui-  (from inputs.project)
+#   * artifact name:    comfyui-quick-start-<run_id>
+#   * result.json is written by the engine and validated against
+#     schemas/result.schema.json before upload.
+#
+# ComfyUI note: upstream auto-detects NPU (torch_npu import +
+# torch.npu.is_available() -> torch.device("npu")), so the doc's server
+# start needs no device flag. The test verifies that via
+# comfy.model_management.get_torch_device() == npu:0.
+#
+# Model download goes through Hugging Face Hub
+# (stable-diffusion-v1-5/stable-diffusion-v1-5) - no ModelScope cache
+# bind mount is needed: NFS already mounts /root/.cache (same setup as
+# the peft trigger).
+
+name: comfyui-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'comfyui-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Same 12 h cadence as the legacy workflows-side trigger.
+    - cron: '45 */12 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/comfyui/**'
+      - 'tests/comfyui/**'
+
+permissions:
+  contents: read
+
+jobs:
+  comfyui-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-comfyui-*), artifacts
+      # (comfyui-quick-start-<run_id>) and the test working dir
+      # (tests/comfyui).
+      project: comfyui
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # 2 h budget: cold-cache download of the ~4.3 GB SD 1.5
+      # v1-5-pruned-emaonly.safetensors via HF Hub plus the ComfyUI
+      # requirements install; hot-cache runs finish well within it.
+      timeout_minutes: 120
+      upstream_repo: comfyanonymous/ComfyUI
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/comfyui/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/comfyui/quick_start.md
+      # cwd is the repo root inside the checkout; env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep and installs live in the test
+      # subclass's prepare_environment hook.
+      test_command: python -m unittest tests.comfyui.test_quick_start_ascend -v 2>&1

--- a/index.rst
+++ b/index.rst
@@ -379,6 +379,12 @@
          <div class="card-footer"><a href="https://github.com/ggerganov/whisper.cpp">官方链接</a><span class="split">|</span><a href="sources/whisper_cpp/install.html">安装指南</a><span class="split">|</span><a href="sources/whisper_cpp/quick_start.html">快速上手</a></div>
       </div>
 
+      <!-- ComfyUI -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/huggingface.png')"></div><h3 class="card-title">ComfyUI</h3></div>
+         <p class="card-desc">模块化的 Stable Diffusion 节点式图形界面与后端，原生适配昇腾 NPU。</p>
+         <div class="card-footer"><a href="https://github.com/comfyanonymous/ComfyUI">官方链接</a><span class="split">|</span><a href="sources/comfyui/quick_start.html">快速上手</a></div>
+      </div>
    </div>
 
 .. -----------------------------------------
@@ -455,4 +461,5 @@
    sources/timm/index.rst
    sources/wenet/index.rst
    sources/whisper_cpp/index.rst
+   sources/comfyui/index.md
 

--- a/sources/comfyui/index.md
+++ b/sources/comfyui/index.md
@@ -1,0 +1,6 @@
+# ComfyUI
+
+ComfyUI 通用文档由上游官方维护。本页收录 Ascend NPU 适配的快速上手。
+
+```{include} quick_start.md
+```

--- a/sources/comfyui/quick_start.md
+++ b/sources/comfyui/quick_start.md
@@ -1,0 +1,296 @@
+# 快速开始 (Ascend NPU)
+
+在单卡昇腾 NPU 上部署 ComfyUI，并用上游自带的 API 例程 `script_examples/basic_api_example.py` 通过 `/prompt` 接口提交默认文生图工作流，端到端产出一张 PNG。
+
+> ComfyUI 原生支持昇腾 NPU：检测到 `torch_npu` 且 `torch.npu.is_available()` 为真时，设备管理自动选用 `npu` 设备，无需额外启动参数。本文以无头服务（默认端口 8188）+ API 例程的方式运行，全程无需人工交互；交互式 Web UI 用户浏览器访问 `http://<机器IP>:8188` 即可。
+
+## 前置条件
+
+### 硬件
+
+Atlas 900 A2 单卡（Ascend NPU），并按需完成物理机或容器内的设备挂载。
+
+### 基础软件
+
+在跑本文档**之前**，你的机器上需要已经装好并可用：
+
+- 可用的 Python 环境
+- 可用的 CANN（参考[快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html)）
+- 与 CANN 匹配的 `torch` + `torch_npu`，且 `torch` 能正常 `import`、`torch.npu.is_available() == True`（参考 [Ascend PyTorch 安装文档](https://gitcode.com/Ascend/pytorch)，按 torch ↔ torch_npu ↔ CANN 三方兼容矩阵选择版本）
+
+按上游 README 的方式设置 CANN 环境变量：
+
+```shell
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+```
+
+### 本文档示例使用的版本
+
+**配套机器**：
+
+- **机器类型**：Atlas 900 A2 单卡
+- **操作系统**：Ubuntu 22.04
+
+**软件版本**：
+
+| 组件 | 版本 |
+| --- | --- |
+| Python | 3.12 |
+| CANN | 9.1.0 |
+| torch | 2.9.0+cpu |
+| torch_npu | 2.9.0.post2 |
+| ComfyUI | master（原生 NPU 支持） |
+| huggingface_hub | 最新稳定版 |
+| 模型 | [stable-diffusion-v1-5/stable-diffusion-v1-5](https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5) 的 `v1-5-pruned-emaonly.safetensors`（经 Hugging Face 下载） |
+
+## 环境检查
+
+检查 Python 版本：
+
+```shell #test id="check-py"
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-py" fuzzy='xxx'
+Python 3.12.xxx
+```
+
+检查 torch / torch_npu 是否装好且 NPU 设备可用：
+
+```shell #test id="check-torch"
+python -c "import torch, torch_npu; print('torch=', torch.__version__); print('torch_npu=', torch_npu.__version__); print('is_available:', torch.npu.is_available()); print('count:', torch.npu.device_count())"
+```
+
+输出结果如下：
+
+```shell #test-result id="check-torch"
+torch= 2.9.0+cpu
+torch_npu= 2.9.0.post2
+is_available: True
+count: 1
+```
+
+```{admonition} Note
+:class: note
+如果 `import torch_npu` 失败，回到 [Ascend PyTorch 安装文档](https://gitcode.com/Ascend/pytorch) 检查 torch / torch_npu / CANN 三方兼容矩阵。
+```
+
+## 获取代码
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+克隆上游仓库并 checkout 到流水线注入的最新 release tag：
+
+```shell #test id="clone-repo" load="upstream_ref>>ref"
+git clone https://github.com/comfyanonymous/ComfyUI.git
+cd ComfyUI
+git checkout <ref>
+echo "HEAD $(git log -1 --format=%h)"
+```
+
+输出结果如下：
+
+```shell #test-result id="clone-repo" fuzzy='xxx'
+HEAD xxx
+```
+
+\<ref> 为流水线注入的上游最新 release tag。
+
+## 安装依赖
+
+ComfyUI 的 `requirements.txt` 里 `torchvision` / `torchaudio` 未 pin 版本。为避免 pip 解析器为满足「最新 torchvision/torchaudio」而把已装好的 `torch 2.9.0` 升级、破坏 torch ↔ torch_npu ↔ CANN 配套，先显式安装与 torch 2.9.0 配套的 pair（`torchvision 0.24.x` ↔ `torchaudio 2.9.x`），已装则跳过；再装 `requirements.txt`（已满足的 `torch` 不会被改动）与 `huggingface_hub`：
+
+```shell #test-setup
+cd ComfyUI
+python -m pip install "torchvision==0.24.0" "torchaudio==2.9.0"
+python -m pip install -r requirements.txt
+python -m pip install huggingface_hub
+```
+
+```{admonition} Note
+:class: note
+- `requirements.txt` 按上游原样安装；`huggingface_hub` 为 Hugging Face 下载模型所需，需显式安装。
+- torch / torch_npu 栈沿用机器上已装好的版本（前置条件），本文档不重装。
+```
+
+验证依赖可用：
+
+```shell #test id="install-deps"
+python -c "import torchsde, einops, transformers, tokenizers, safetensors, aiohttp, PIL, av, huggingface_hub; print('deps ok')"
+```
+
+输出结果如下：
+
+```shell #test-result id="install-deps"
+deps ok
+```
+
+## 下载模型
+
+默认使用 **Hugging Face Hub** 进行模型下载。
+
+```shell #test-setup store="model_dir"
+python -c "
+import time, sys
+from pathlib import Path
+from huggingface_hub import snapshot_download
+d = None
+for i in range(3):
+    try:
+        d = snapshot_download('stable-diffusion-v1-5/stable-diffusion-v1-5', allow_patterns=['v1-5-pruned-emaonly.safetensors'])
+        if (Path(d) / 'v1-5-pruned-emaonly.safetensors').is_file():
+            break
+        print('attempt %d/3: file not complete, retrying' % (i+1), file=sys.stderr)
+        d = None
+    except Exception as e:
+        print('attempt %d/3 failed: %s' % (i+1, e), file=sys.stderr)
+        time.sleep(15)
+assert d, 'snapshot_download failed after 3 attempts'
+print(d)
+" | tail -n 1
+```
+
+```{admonition} Note
+:class: note
+- `tail -n 1` 过滤下载进度输出，仅保留模型目录路径。
+- `allow_patterns` 只下载 `v1-5-pruned-emaonly.safetensors`（约 4.3 GB，SD 1.5 单文件 checkpoint，即 `basic_api_example.py` 默认工作流引用的 `ckpt_name`），跳过仓库里的 diffusers 分片格式，首次运行请耐心等待。
+```
+
+## 启动服务（单卡 NPU）
+
+把 checkpoint 链接进 `models/checkpoints/`（`CheckpointLoaderSimple` 的 `ckpt_name` 按文件名索引），后台启动 ComfyUI 服务：
+
+```shell #test-setup store="server_pid" load="model_dir>>model"
+cd ComfyUI
+mkdir -p models/checkpoints
+ln -sf <model>/v1-5-pruned-emaonly.safetensors models/checkpoints/
+nohup python main.py --disable-auto-launch --listen 127.0.0.1 --port 8188 > /tmp/comfyui.log 2>&1 &
+echo $!
+```
+
+- `--disable-auto-launch`：无头容器内不要尝试拉起浏览器。
+- 设备选择由 `comfy/model_management.py` 自动完成（检测到 `torch_npu` 即用 `npu` 设备），无需额外参数。
+
+等待服务就绪：
+
+```shell #test id="wait-ready"
+for i in $(seq 1 120); do
+  curl -sf http://127.0.0.1:8188/system_stats > /dev/null && break
+  sleep 5
+done
+curl -sf http://127.0.0.1:8188/system_stats > /dev/null || { echo "server not ready"; tail -n 100 /tmp/comfyui.log; exit 1; }
+echo "server ready"
+```
+
+输出结果如下：
+
+```shell #test-result id="wait-ready"
+server ready
+```
+
+确认 ComfyUI 的设备管理选中的是 NPU：
+
+```shell #test id="check-device"
+cd ComfyUI
+python -c "import comfy.model_management as mm; print('comfy device:', mm.get_torch_device())"
+```
+
+输出结果如下：
+
+```shell #test-result id="check-device"
+comfy device: npu...
+```
+
+```{admonition} Note
+:class: note
+`get_torch_device()` 与服务进程走同一套检测逻辑，单卡上返回 `npu:0`。
+```
+
+## 运行 API 例程（文生图）
+
+提交上游例程 `script_examples/basic_api_example.py`（默认文生图工作流：SD 1.5，512x512，20 步 euler），轮询 `/queue` 等待出图完成：
+
+```shell #test id="run-example"
+cd ComfyUI
+python script_examples/basic_api_example.py && echo "prompt queued"
+python - <<'EOF'
+import json, time, sys
+from urllib import request
+
+deadline = time.time() + 900
+while time.time() < deadline:
+    try:
+        with request.urlopen('http://127.0.0.1:8188/queue') as r:
+            d = json.load(r)
+    except Exception as e:
+        print('queue poll error:', e)
+        sys.exit(1)
+    run = len(d.get('queue_running') or [])
+    pend = len(d.get('queue_pending') or [])
+    if (run, pend) == (0, 0):
+        print('queue drained')
+        sys.exit(0)
+    time.sleep(5)
+print('queue not drained before deadline')
+sys.exit(1)
+EOF
+ls output/ComfyUI_*.png > /dev/null 2>&1 || { echo "no output image"; tail -n 100 /tmp/comfyui.log; exit 1; }
+ls output/ComfyUI_*.png | tail -n 1
+```
+
+输出结果如下：
+
+```shell #test-result id="run-example" fuzzy='...' fuzzy='xxx'
+...prompt queued
+...queue drained
+...ComfyUI_000xxx
+```
+
+```{admonition} Note
+:class: note
+- `basic_api_example.py` 只负责把工作流 POST 到 `/prompt`（不等待执行完成），完成后轮询 `/queue` 直到 running / pending 均清空。
+- `SaveImage` 节点把结果写到 `output/ComfyUI_00001_.png`（全新 checkout 首跑序号为 00001）。
+- 20 步 SD 1.5 在单卡 NPU 上数分钟内完成；若 15 分钟未排空按失败处理。
+```
+
+## 检查生成结果
+
+```shell #test id="check-png"
+cd ComfyUI
+python -c "
+import glob
+paths = glob.glob('output/ComfyUI_*.png')
+assert paths, 'no output png'
+data = open(paths[0], 'rb').read()
+assert data[:8] == b'\x89PNG\r\n\x1a\n', 'not a png'
+assert len(data) > 10000, 'png too small: %d' % len(data)
+print('png ok:', paths[0], len(data), 'bytes')
+"
+```
+
+输出结果如下：
+
+```shell #test-result id="check-png" fuzzy='...' fuzzy='xxx'
+png ok: ...ComfyUI_000xxx bytes
+```
+
+```{admonition} Note
+:class: note
+校验 PNG 魔数与体积下限，确保 NPU 上产出的不是空图或损坏文件。
+```
+
+## 清理
+
+<!--
+```shell #test-setup load="server_pid>>pid"
+kill -9 <pid> 2>/dev/null || true
+sleep 2
+echo "comfyui stopped"
+```
+-->

--- a/tests/comfyui/__init__.py
+++ b/tests/comfyui/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent package marker
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/comfyui/__init__.py -> parents[0]=tests/comfyui,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/comfyui/test_quick_start_ascend.py
+++ b/tests/comfyui/test_quick_start_ascend.py
@@ -1,0 +1,258 @@
+"""Quick-start test: doc under test is ``sources/comfyui/quick_start.md``.
+
+End-to-end case built on top of the ``MarkdownDocTestBase`` contract:
+env check + ComfyUI clone/install + SD 1.5 checkpoint download
+(Hugging Face Hub) + headless ComfyUI server on NPU + the upstream API
+example ``script_examples/basic_api_example.py`` producing a PNG.
+
+Run: ``python -m unittest tests.comfyui.test_quick_start_ascend -v 2>&1``
+
+Environment variables (injected by GitHub workflow
+``comfyui-quick-start.yml``):
+    ``MONITORED_DOC_URL``         doc to fetch and execute
+    ``UPSTREAM_REF``              release tag substituted into the doc's <ref>
+    ``NPU_READY=true``            Required, otherwise the class is skipped.
+                                  End-to-end tests only run on the NPU runner:
+                                  local dev machines / normal ubuntu runners
+                                  have no ``/dev/davinci*`` device, and the
+                                  hard run would fail on ``import torch_npu``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    diagnose_mount_environment,
+    ensure_safetensors,
+    purge_huggingface_corrupt,
+    report_huggingface_state,
+    resolve_huggingface_cache,
+)
+
+
+def _is_truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    # 60 min per command: long enough for the ~4.3 GB SD 1.5
+    # v1-5-pruned-emaonly.safetensors snapshot_download on the first run
+    # plus the pip install of ComfyUI requirements, which needs longer
+    # than the 20 min default of the smaller projects.
+    DEFAULT_COMMAND_TIMEOUT = 3600
+
+    USER_AGENT = 'cosdt-ci-test/quick-start'  # monitored source lives under this org
+
+    # Extend the base ERROR_MARKERS with CANN's typo + sentinel so a CANN
+    # failure surfaces a full stderr dump (head/tail by default would hide
+    # the line that names the failure).
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,  # generic [ERROR] + Traceback
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'ERR99999',  # CANN sentinel for unrecoverable runtime failure
+    )
+
+    # Process-level CUDA exclusion list. Same rationale as the other
+    # projects' tests: write to /tmp and export, so subprocesses
+    # (subprocess.run inherits parent env by default) see it. ComfyUI's
+    # dep tree itself doesn't pull CUDA, but bare ``torch`` / ``torchvision``
+    # wheels from the default PyPI index depend on nvidia-* packages; the
+    # constraints keep any accidental re-resolution of the torch stack
+    # from dragging them in and breaking the torch_npu pairing.
+    _CUDA_CONSTRAINTS = (
+        'cuda-toolkit<0',
+        'cuda-python<0',
+        'cuda-bindings<0',
+        'cuda-core<0',
+        'cuda-pathfinder<0',
+        'flashinfer-python<0',
+        'nvidia-cublas<0',
+        'nvidia-cuda-runtime<0',
+        'nvidia-cuda-nvrtc<0',
+        'nvidia-cuda-cupti<0',
+        'nvidia-cudnn<0',
+        'nvidia-cudnn-frontend<0',
+        'nvidia-cufft<0',
+        'nvidia-curand<0',
+        'nvidia-cusolver<0',
+        'nvidia-cusparse<0',
+        'nvidia-cutlass-dsl<0',
+        'nvidia-cutlass-dsl-libs-base<0',
+        'nvidia-cutlass-dsl-libs-core<0',
+        'nvidia-cutlass-dsl-libs-cu12<0',
+        'nvidia-ml-py<0',
+        'nvidia-nccl<0',
+        'nvidia-nvjitlink<0',
+        'nvidia-nvtx<0',
+        'nvidia-cublas-cu12<0',
+        'nvidia-cuda-nvdisasm<0',
+        'nvidia-cuda-runtime-cu12<0',
+        'nvidia-cuda-nvrtc-cu12<0',
+        'nvidia-cuda-cupti-cu12<0',
+        'nvidia-cudnn-cu12<0',
+        'nvidia-cufft-cu12<0',
+        'nvidia-curand-cu12<0',
+        'nvidia-cusolver-cu12<0',
+        'nvidia-cusparse-cu12<0',
+        'nvidia-cusparselt-cu12<0',
+        'nvidia-nccl-cu12<0',
+        'nvidia-nvjitlink-cu12<0',
+        'nvidia-nvtx-cu12<0',
+    )
+    _CONSTRAINTS_FILE = '/tmp/comfyui_npu_constraints.txt'
+
+    # Cluster-internal nginx PyPI cache + Huawei Cloud ascend dual-source.
+    _CLUSTER_INDEX = 'http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple'
+    _ASCEND_EXTRA = 'https://repo.huaweicloud.com/ascend/repos/pypi'
+
+    # HF repo carrying the v1-5-pruned-emaonly.safetensors checkpoint
+    # referenced by basic_api_example.py (replaces the former ModelScope
+    # AI-ModelScope/stable-diffusion-v1-5 download used on the workflows
+    # side - docs CI standardizes on Hugging Face).
+    _MODEL_ID = 'stable-diffusion-v1-5/stable-diffusion-v1-5'
+
+    # CANN toolkit: source once to get ASCEND_HOME / LD_LIBRARY_PATH etc.
+    # Path is hard-coded, tied to the container image pinned by the
+    # ``image:`` input of ``comfyui-quick-start.yml``.
+    _CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN env + write CUDA exclusion list + install uv +
+        torch stack probe + safetensors + HF cache validation.
+
+        The doc's ``## 安装依赖`` block is the single source of truth for
+        which ComfyUI deps get installed; this class only handles
+        ``torch`` / ``torch_npu`` here (via the cluster cache + Huawei
+        ascend dual-source). Everything else installs in document order
+        via the ``#test`` machinery.
+        """
+        # 0) CANN env: source set_env.sh and merge the env stream into
+        # os.environ
+        if os.path.isfile(cls._CANN_SET_ENV):
+            merged = subprocess.run(
+                ['bash', '-c', f'source {cls._CANN_SET_ENV} >/dev/null 2>&1; env'],
+                capture_output=True, text=True, check=True,
+            )
+            for line in merged.stdout.splitlines():
+                if '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                # Don't overwrite envs explicitly injected by the
+                # workflow (jobs.env / steps.env); only fill in CANN
+                # keys that are missing, to avoid conflicts.
+                os.environ.setdefault(key, value)
+            print('setup: sourced CANN env from set_env.sh')
+        else:
+            print(
+                f'setup: skipping CANN env source ({cls._CANN_SET_ENV} not present)'
+            )
+
+        # 1) CUDA exclusion list + process-level env
+        with open(cls._CONSTRAINTS_FILE, 'w', encoding='utf-8') as fh:
+            fh.write('\n'.join(cls._CUDA_CONSTRAINTS) + '\n')
+        os.environ['PIP_CONSTRAINT'] = cls._CONSTRAINTS_FILE
+        os.environ['UV_CONSTRAINT'] = cls._CONSTRAINTS_FILE
+
+        # 2) uv: the doc's install blocks call ``pip``; keep uv installed
+        # for parity with the other projects' setup. Inherit
+        # ``PIP_INDEX_URL`` + ``PIP_TRUSTED_HOST`` from the yml job-level
+        # env (cluster cache path + trusted-host).
+        subprocess.run(
+            ['python', '-m', 'pip', 'install', 'uv'],
+            check=True,
+        )
+
+        # 3) torch stack probe: when version matches the image's
+        # pre-installed wheels, reuse them to avoid the cluster cache
+        # triggering ``+cpu`` resolution.
+        _PROBE_SCRIPT = (
+            'import torch, torch_npu\n'
+            "raise SystemExit(0 if "
+            "torch.__version__.startswith('2.9.0') "
+            "and torch_npu.__version__.startswith('2.9.0') "
+            "else 1)"
+        )
+        probe = subprocess.run(
+            ['python', '-c', _PROBE_SCRIPT],
+            capture_output=True,
+            check=False,  # probe's success/failure is the branch signal — don't raise
+        )
+        if probe.returncode == 0:
+            _VERSIONS_SCRIPT = (
+                'import torch, torch_npu; '
+                'print(torch.__version__, torch_npu.__version__)'
+            )
+            versions = subprocess.run(
+                ['python', '-c', _VERSIONS_SCRIPT],
+                capture_output=True, text=True, check=True,
+            )
+            print(f'setup: reusing image torch stack ({versions.stdout.strip()})')
+        else:
+            print('setup: installing torch==2.9.0 torch_npu==2.9.0.post2')
+            subprocess.run(
+                [
+                    'python', '-m', 'pip', 'install',
+                    '--index-url', cls._CLUSTER_INDEX,
+                    '--extra-index-url', cls._ASCEND_EXTRA,
+                    'torch==2.9.0', 'torch_npu==2.9.0.post2',
+                ],
+                check=True,
+            )
+
+        # 4) safetensors: native loader used by the cache validation
+        # step below. Pulled in transitively by torch on most images;
+        # install defensively in case the CANN base ships without it.
+        ensure_safetensors()
+
+        # 5) tqdm: required by huggingface_hub download progress bars.
+        subprocess.run(
+            ['python', '-m', 'pip', 'install', 'tqdm'],
+            check=True,
+        )
+
+        # 6) HF cache validation: the doc downloads the SD 1.5 checkpoint
+        # (stable-diffusion-v1-5/stable-diffusion-v1-5) via Hugging Face
+        # Hub on the first run. A persistent host-side cache can hold
+        # truncated safetensors from interrupted runs; report the current
+        # state, then walk every shard under each model dir and purge it
+        # on failure so the next access re-downloads cleanly.
+        diagnose_mount_environment(model_id=cls._MODEL_ID)
+
+        report_huggingface_state(cls._MODEL_ID)
+        purge_huggingface_corrupt(resolve_huggingface_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing on
+        non-NPU runners.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Template-method entry point. The base class ``run_template()``
+        runs the full ``pre_process`` -> ``parse`` -> ``execute`` ->
+        ``post_process`` flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 概述

将 ComfyUI 的 quick start 看护从 workflows 仓库迁移到 docs 仓库，对齐 #142（peft）确立的模式：以 Markdown 文档作为测试用例（`#test` / `#test-setup` / `#test-result` 标注），由本仓库公共引擎 `.github/workflows/quick-start-template.yml` 在自托管 NPU runner 上执行并持续看护。

## 变更内容

| 文件 | 说明 |
| --- | --- |
| `sources/comfyui/index.md` | ComfyUI 文档入口，include 快速上手正文 |
| `sources/comfyui/quick_start.md` | 快速上手正文：环境检查 → 克隆 ComfyUI → 安装依赖 → 下载 SD 1.5 checkpoint → 启动 NPU 服务 → API 例程文生图 → PNG 结果校验 |
| `tests/comfyui/test_quick_start_ascend.py` | `MarkdownDocTestBase` 测试子类：CANN 环境注入、CUDA 排除表、torch 栈探针、HF 缓存状态上报与坏片清理 |
| `tests/comfyui/__init__.py` | 测试包引导（`sys.path` 注入） |
| `.github/workflows/comfyui-quick-start.yml` | 项目薄触发器：12h 定时 + workflow_dispatch + PR 路径过滤（`sources/comfyui/**`、`tests/comfyui/**`），复用公共 quick-start 引擎 |
| `index.rst` | 多模态分区注册 ComfyUI 卡片与 toctree 条目（置于 whisper_cpp 之后）；已有内容零改动，仅两处纯新增 |

## 与 workflows 侧版本的差异

- 模型下载由 ModelScope 改为 **Hugging Face Hub**（`stable-diffusion-v1-5/stable-diffusion-v1-5` 的 `v1-5-pruned-emaonly.safetensors`），依赖安装同步由 `modelscope` 替换为 `huggingface_hub`，符合 docs CI 统一走 HF 的约定。
- 测试侧缓存校验对应切换为 HF 系函数（`report_huggingface_state` / `purge_huggingface_corrupt` / `resolve_huggingface_cache`）。

## 测试计划

- [ ] 手动 `workflow_dispatch` 触发 `comfyui-quick-start`，确认自托管 NPU runner 上端到端出图成功
- [ ] 确认 PR 路径过滤只在本目录变更时触发看护
- [ ] 确认 `index.rst` 渲染后卡片与侧边栏导航正常
