### PR TITLE
[feature] 迁移 onnxruntime Quick Start 并接入看护

### DIFF
--- a/.github/workflows/onnxruntime-quick-start.yml
+++ b/.github/workflows/onnxruntime-quick-start.yml
@@ -1,0 +1,68 @@
+# onnxruntime quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+
+name: onnxruntime-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'onnxruntime-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Offset from peft's '30 */3 * * *' and llama.cpp's '45 */3 * * *'
+    # so the compile job does not start on the same minute.
+    - cron: '25 */3 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/onnxruntime/**'
+      - 'tests/onnxruntime/**'
+
+permissions:
+  contents: read
+
+jobs:
+  onnxruntime-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-onnxruntime-*), artifacts
+      # (onnxruntime-quick-start-<run_id>) and the test working dir
+      # (workflows/tests/onnxruntime).
+      project: onnxruntime
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # Source-build budget. Do not add a container bind-mount for
+      # /root/.cache: the runner NFS already persists that tree. Hidden
+      # #test-setup restores/saves the wheel and clone under
+      # /root/.cache/huggingface/onnxruntime/.
+      timeout_minutes: 300
+      upstream_repo: microsoft/onnxruntime
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/onnxruntime/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/onnxruntime/quick_start.md
+      # cwd is the repo root inside the `workflows` checkout (matches
+      # engine template's `working-directory: workflows`); env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep lives in the test subclass's
+      # prepare_environment hook.
+      test_command: python -m unittest tests.onnxruntime.test_quick_start_ascend -v 2>&1

--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,11 @@ language = 'zh_CN'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'README.md',
-                    '.github', 'tests']
+                    '.github', 'tests',
+                    # Guard / CI source of truth; Sphinx includes it into
+                    # sources/onnxruntime/index.rst so the sidebar landing
+                    # page is the tutorial, not a nested「快速开始」child page.
+                    'sources/onnxruntime/quick_start.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -257,11 +257,11 @@
          <div class="card-footer"><a href="https://github.com/InternLM/lmdeploy">官方链接</a><span class="split">|</span><a href="https://lmdeploy.readthedocs.io/en/latest/">文档中心</a><span class="split">|</span><a href="https://lmdeploy.readthedocs.io/en/latest/get_started/ascend/get_started.html">昇腾教程</a></div>
       </div>
 
-      <!-- ONNX Runtime：官方文档站已含 CANN/昇腾说明，外链跳转，不再本地编译 -->
+      <!-- onnxruntime -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/onnxruntime.png')"></div><h3 class="card-title">onnxruntime</h3></div>
          <p class="card-desc">跨平台高性能推理加速器，v1.13.1 起支持昇腾。</p>
-         <div class="card-footer"><a href="https://github.com/microsoft/onnxruntime">官方链接</a><span class="split">|</span><a href="https://onnxruntime.ai/docs/">文档中心</a><span class="split">|</span><a href="https://onnxruntime.ai/docs/execution-providers/community-maintained/CANN-ExecutionProvider.html">昇腾教程</a></div>
+         <div class="card-footer"><a href="https://github.com/microsoft/onnxruntime">官方链接</a><span class="split">|</span><a href="https://onnxruntime.ai/docs/">文档中心</a><span class="split">|</span><a href="sources/onnxruntime/index.html">快速上手</a></div>
       </div>
 
       <!-- Sentence Transformers -->

--- a/sources/onnxruntime/index.rst
+++ b/sources/onnxruntime/index.rst
@@ -1,8 +1,2 @@
-onnxruntime
-===========
-
-昇腾相关文档由 ONNX Runtime 官方维护，请访问官方文档站：
-
-- GitHub：`onnxruntime <https://github.com/microsoft/onnxruntime>`_
-- 文档中心：`ONNX Runtime Docs <https://onnxruntime.ai/docs/>`_
-- 昇腾教程：`CANN Execution Provider <https://onnxruntime.ai/docs/execution-providers/community-maintained/CANN-ExecutionProvider.html>`_
+.. include:: quick_start.md
+   :parser: myst_parser.sphinx_

--- a/sources/onnxruntime/quick_start.md
+++ b/sources/onnxruntime/quick_start.md
@@ -1,0 +1,375 @@
+# onnxruntime
+
+本文在单卡昇腾上从 [ONNX Runtime](https://github.com/microsoft/onnxruntime) 当前正式 Release 源码编译 `onnxruntime-cann`，当场生成一个最小加法模型，并用 [CANN Execution Provider](https://onnxruntime.ai/docs/execution-providers/community-maintained/CANN-ExecutionProvider.html) 做一次推理。包名是 `onnxruntime-cann`，导入名仍是 `onnxruntime`；不要再装一份 CPU 包 `onnxruntime`，两个包会抢同一个导入名。
+
+## 前置条件
+
+### 硬件
+
+Atlas **800T** / **900 A2** 训练系列（Ascend **910B**）。本文示例为单卡。
+
+### 软件
+
+| 类别 | 要求 |
+| --- | --- |
+| CANN | toolkit 与驱动已安装，并能 `source /usr/local/Ascend/ascend-toolkit/set_env.sh` |
+| Python | 3.12 |
+| 编译 | gcc-12、g++-12、cmake 3.28 到 3.31、ninja、git |
+| 包管理 | `python -m pip` |
+
+阅读本文前，请先按 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 装好 CANN 与驱动。推荐配套镜像：`swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12`。
+
+| 组件 | 版本 |
+| --- | --- |
+| Python | 3.12 |
+| CANN | 9.1.0 |
+| onnxruntime-cann | 当前 GitHub 正式 Release 源码编译 |
+| numpy | 1.26.x，必须 `<2` |
+
+## 1. 加载 CANN 环境
+
+常见容器里 `npu-smi` 位于 `/usr/local/sbin` 或 `/usr/local/bin`。先把这两个目录放进 `PATH`，再加载 CANN：
+
+```shell
+export PATH=/usr/local/sbin:/usr/local/bin:$PATH
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+```
+
+## 2. 检查环境是否就绪
+
+### 2.1 确认 NPU 在线
+
+```shell
+npu-smi info
+```
+
+如果 `npu-smi` 找不到，回到 [快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html) 检查驱动与设备挂载。
+
+### 2.2 确认工具可用
+
+下面确认 CANN 已加载，并且 `npu-smi` 与 `python` 都在 `PATH` 里。
+
+```shell #test id="check-tools"
+test -n "$ASCEND_HOME_PATH"
+command -v npu-smi >/dev/null
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-tools"
+Python 3.12...
+```
+
+## 3. 安装编译工具
+
+Ubuntu 22.04 默认 gcc 11 编不了 aarch64 上的 ONNX Runtime，需要 gcc-12。cmake 需要 3.28 及以上且不要装到 4；`python -m pip` 装的 cmake 要放到 `PATH` 前面，否则会继续用系统自带的 3.22。
+
+<!--
+```shell #test-setup
+if getent hosts cache-service.nginx-pypi-cache.svc.cluster.local >/dev/null 2>&1 \
+    && [ -f /etc/apt/sources.list ]; then
+  sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+fi
+```
+-->
+
+```shell #test id="toolchain"
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v gcc-12 >/dev/null || ! command -v g++-12 >/dev/null || ! command -v ninja >/dev/null; then
+  apt-get update
+  apt-get install -y gcc-12 g++-12 ninja-build git
+fi
+python -m pip install --retries 3 'cmake>=3.28,<4' 'numpy<2' packaging wheel setuptools
+export PATH="$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))'):$PATH"
+hash -r
+gcc-12 --version | head -n 1
+cmake --version | head -n 1
+```
+
+输出结果如下：
+
+```shell #test-result id="toolchain"
+...gcc-12...
+cmake version 3.3...
+```
+
+## 4. 获取源码
+
+工作目录为 `/root/onnxruntime-qs`。把 `<UPSTREAM_REF>` 换成 [Releases](https://github.com/microsoft/onnxruntime/releases) 里当前正式 tag。
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+<!--
+```shell #test-setup load="upstream_ref>>UPSTREAM_REF"
+wd=/root/onnxruntime-qs
+ci=/root/.cache/huggingface/onnxruntime
+ref='<UPSTREAM_REF>'
+mkdir -p "$wd/dist"
+for w in "$ci/wheels/$ref"/onnxruntime_cann-*.whl; do
+  [ -f "$w" ] || continue
+  if python -m zipfile -l "$w" >/dev/null 2>&1; then
+    cp -a "$w" "$wd/dist/"
+  else
+    rm -f "$w"
+  fi
+done
+if [ -d "$ci/src/$ref/.git" ] && [ ! -d "$wd/onnxruntime/.git" ]; then
+  rm -rf "$wd/onnxruntime"
+  git clone --depth 1 "$ci/src/$ref" "$wd/onnxruntime"
+fi
+```
+-->
+
+```shell #test id="clone" load="upstream_ref>>UPSTREAM_REF"
+mkdir -p /root/onnxruntime-qs
+if [ ! -d /root/onnxruntime-qs/onnxruntime/.git ]; then
+  GIT_TERMINAL_PROMPT=0 GIT_HTTP_VERSION=HTTP/1.1 git clone --depth 1 --branch "<UPSTREAM_REF>" \
+    https://github.com/microsoft/onnxruntime.git /root/onnxruntime-qs/onnxruntime
+fi
+ls /root/onnxruntime-qs/onnxruntime/build.sh
+```
+
+输出结果如下：
+
+```shell #test-result id="clone"
+/root/onnxruntime-qs/onnxruntime/build.sh
+```
+
+## 5. 编译 onnxruntime-cann
+
+开启 CANN Execution Provider 并打出 Python wheel。工作目录里如果已有 `dist/onnxruntime_cann-*.whl`，这一步会跳过编译；首次编译可能要几十分钟，并行路数封顶 32。
+
+<!--
+```shell #test-setup
+wd=/root/onnxruntime-qs
+ci=/root/.cache/huggingface/onnxruntime
+if [ -d "$ci/cmake-mirror" ] && [ -d "$wd/onnxruntime" ]; then
+  ln -sfn "$ci/cmake-mirror" "$wd/onnxruntime/.cmake-mirror"
+fi
+```
+-->
+
+```shell #test id="compile"
+cd /root/onnxruntime-qs
+if ! compgen -G "dist/onnxruntime_cann-*.whl" >/dev/null; then
+  cd onnxruntime
+  export CC=gcc-12 CXX=g++-12
+  njobs=$(nproc)
+  if [ "$njobs" -gt 32 ]; then
+    njobs=32
+  fi
+  MIRROR=()
+  if [ -d .cmake-mirror ]; then
+    MIRROR+=(--cmake_deps_mirror_dir "$PWD/.cmake-mirror")
+  fi
+  ./build.sh --config Release --build_shared_lib --use_cann --build_wheel \
+    --parallel "$njobs" --skip_tests --skip_submodule_sync \
+    --compile_no_warning_as_error --allow_running_as_root \
+    --cmake_generator Ninja \
+    --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
+    "${MIRROR[@]}"
+  mkdir -p /root/onnxruntime-qs/dist
+  cp -a build/Linux/Release/dist/onnxruntime_cann-*.whl /root/onnxruntime-qs/dist/
+fi
+ls /root/onnxruntime-qs/dist/onnxruntime_cann-*.whl
+```
+
+输出结果如下：
+
+```shell #test-result id="compile"
+...onnxruntime_cann-...whl
+```
+
+<!--
+```shell #test-setup load="upstream_ref>>UPSTREAM_REF"
+wd=/root/onnxruntime-qs
+ci=/root/.cache/huggingface/onnxruntime
+ref='<UPSTREAM_REF>'
+mkdir -p "$ci/wheels/$ref"
+for w in "$wd/dist"/onnxruntime_cann-*.whl; do
+  [ -f "$w" ] || continue
+  base=$(basename "$w")
+  dest="$ci/wheels/$ref/$base"
+  if [ -f "$dest" ]; then
+    continue
+  fi
+  cp -a "$w" "${dest}.part"
+  mv "${dest}.part" "$dest"
+done
+if [ -d "$wd/onnxruntime/.git" ] && [ ! -d "$ci/src/$ref/.git" ]; then
+  mkdir -p "$ci/src"
+  rm -rf "$ci/src/${ref}.part"
+  git clone --depth 1 "$wd/onnxruntime" "$ci/src/${ref}.part"
+  mv "$ci/src/${ref}.part" "$ci/src/$ref"
+fi
+```
+-->
+
+## 6. 安装 wheel 与算子编译依赖
+
+把刚编出的 `onnxruntime-cann` 装进当前 Python。`onnx` 用来当场生成模型；这个 wheel 按 NumPy 1.x 编译，不钉 `numpy<2` 时 `import onnxruntime` 会失败。CANN 编译算子还要用 `decorator`、`scipy`、`attrs`、`psutil`、`sympy`，不装的话第一次 `sess.run()` 会报 `aclgrphBuildInitialize` 或 `aclopCompileAndExecute`。
+
+```shell #test id="install"
+python -m pip install --retries 3 \
+    /root/onnxruntime-qs/dist/onnxruntime_cann-*.whl \
+    onnx \
+    'numpy<2' \
+    decorator \
+    'scipy>=1.11,<1.15' \
+    attrs \
+    psutil \
+    sympy
+python -c "from importlib.metadata import version; print('onnxruntime-cann', version('onnxruntime-cann'))"
+```
+
+输出结果如下：
+
+```shell #test-result id="install"
+...onnxruntime-cann ...
+```
+
+## 7. 确认昇腾后端
+
+下面列出当前 Python 里已注册的 Execution Provider。没有 `CANNExecutionProvider` 时不要继续推理，先看文末常见问题。
+
+```shell #test id="providers"
+python -c "import onnxruntime; print(onnxruntime.get_available_providers())"
+```
+
+输出结果如下：
+
+```shell #test-result id="providers"
+...CANNExecutionProvider...
+```
+
+列表里有 CPU 并不等于这次推理会走 CPU。真正决定后端的是下一节创建 `InferenceSession` 时传入的 `providers`。
+
+## 8. 造一个最小 ONNX 模型
+
+用已安装的 `onnx` 写一个两向量相加的图，生成工作目录里的 `add_model.onnx`。
+
+保存为 `/root/onnxruntime-qs/make_add_model.py`：
+
+```python
+import onnx
+from onnx import TensorProto, helper
+
+x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2])
+y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2])
+z = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [2])
+graph = helper.make_graph(
+    [helper.make_node("Add", ["X", "Y"], ["Z"])],
+    "add",
+    [x, y],
+    [z],
+)
+model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+onnx.save(model, "add_model.onnx")
+print("wrote add_model.onnx")
+```
+
+<!--
+```shell #test-setup
+mkdir -p /root/onnxruntime-qs
+cat > /root/onnxruntime-qs/make_add_model.py <<'PY'
+import onnx
+from onnx import TensorProto, helper
+
+x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2])
+y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2])
+z = helper.make_tensor_value_info("Z", TensorProto.FLOAT, [2])
+graph = helper.make_graph(
+    [helper.make_node("Add", ["X", "Y"], ["Z"])],
+    "add",
+    [x, y],
+    [z],
+)
+model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+onnx.save(model, "add_model.onnx")
+print("wrote add_model.onnx")
+PY
+```
+-->
+
+```shell #test id="make-model"
+cd /root/onnxruntime-qs
+python make_add_model.py
+```
+
+输出结果如下：
+
+```shell #test-result id="make-model"
+wrote add_model.onnx
+```
+
+## 9. 用昇腾跑第一次推理
+
+ONNX Runtime 默认 `enable_fallback=1`：CANN 会话创建失败时会静默改在 CPU 上重建会话，加法结果仍然正确。这里只注册 `CANNExecutionProvider`，并同时关掉会话级和 Python 级回退。
+
+输入是 `[1.0, 2.0]` 和 `[3.0, 4.0]`，昇腾上的加法结果应是 `[4.0, 6.0]`。
+
+保存为 `/root/onnxruntime-qs/infer_add.py`：
+
+```python
+import numpy as np
+import onnxruntime as ort
+
+so = ort.SessionOptions()
+so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+sess = ort.InferenceSession(
+    "add_model.onnx",
+    sess_options=so,
+    providers=["CANNExecutionProvider"],
+    enable_fallback=False,
+)
+providers = sess.get_providers()
+print(providers)
+assert providers[0] == "CANNExecutionProvider", providers
+x = np.array([1.0, 2.0], dtype=np.float32)
+y = np.array([3.0, 4.0], dtype=np.float32)
+out = sess.run(None, {"X": x, "Y": y})[0]
+print("result", [float(v) for v in out])
+```
+
+<!--
+```shell #test-setup
+mkdir -p /root/onnxruntime-qs
+cat > /root/onnxruntime-qs/infer_add.py <<'PY'
+import numpy as np
+import onnxruntime as ort
+
+so = ort.SessionOptions()
+so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+sess = ort.InferenceSession(
+    "add_model.onnx",
+    sess_options=so,
+    providers=["CANNExecutionProvider"],
+    enable_fallback=False,
+)
+providers = sess.get_providers()
+print(providers)
+assert providers[0] == "CANNExecutionProvider", providers
+x = np.array([1.0, 2.0], dtype=np.float32)
+y = np.array([3.0, 4.0], dtype=np.float32)
+out = sess.run(None, {"X": x, "Y": y})[0]
+print("result", [float(v) for v in out])
+PY
+```
+-->
+
+```shell #test id="infer"
+cd /root/onnxruntime-qs
+python infer_add.py
+```
+
+输出结果如下。第一项必须是 `CANNExecutionProvider`。
+
+```shell #test-result id="infer"
+...CANNExecutionProvider...
+result [4.0, 6.0]
+```

--- a/tests/onnxruntime/__init__.py
+++ b/tests/onnxruntime/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent ``__init__.py``
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/onnxruntime/__init__.py -> parents[0]=tests/onnxruntime,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/onnxruntime/test_quick_start_ascend.py
+++ b/tests/onnxruntime/test_quick_start_ascend.py
@@ -1,0 +1,120 @@
+"""Quick-start test: doc under test is ``sources/onnxruntime/quick_start.md``.
+
+Run: ``python -m unittest tests.onnxruntime.test_quick_start_ascend -v 2>&1``
+
+Env (injected by the engine ``quick-start-template.yml``, triggered by
+``onnxruntime-quick-start.yml``): ``MONITORED_DOC_URL``, ``UPSTREAM_REF``,
+``NPU_READY=true`` (otherwise the class is skipped).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import unittest
+from pathlib import Path
+
+from doc_test.base import MarkdownDocTestBase
+
+_CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+
+
+def _is_truthy(value: str | None) -> bool:
+    """``'true'`` -> True (case-insensitive); anything else (including unset) -> False."""
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    """Return True when ``NPU_READY=true`` is set, releasing the skip."""
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    """End-to-end test: fetch doc -> validate contract -> run ``#test-setup``
+    / ``#test`` in order -> compare against ``#test-result``."""
+
+    # Source build of onnxruntime-cann can take over an hour; the base
+    # class uses one timeout for every subprocess.
+    DEFAULT_COMMAND_TIMEOUT = 10800
+    USER_AGENT = 'ascend-docs/quick-start'
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'ERR99999',
+        'CANN failure',
+        'aclgrphBuildInitialize',
+        'aclopCompileAndExecute',
+        'ACL_ERROR_FAILURE',
+    )
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN env once so later ``bash -c`` blocks inherit it.
+
+        Class-level setup: run once per test class, triggered by
+        ``setUpClass``. Each labeled fence is a new subprocess, so a
+        ``source set_env.sh`` block in the document does not persist.
+
+        Merge is overwrite, not ``setdefault``: the container image may
+        already ship ``LD_LIBRARY_PATH``, which would otherwise hide the
+        CANN increment from ``set_env.sh``.
+        """
+        if not os.path.isfile(_CANN_SET_ENV):
+            raise RuntimeError(
+                f'required Ascend env script missing: {_CANN_SET_ENV}'
+            )
+        sourced = f'source {shlex.quote(_CANN_SET_ENV)} >/dev/null 2>&1'
+        merged = subprocess.run(
+            ['bash', '-c', f'{sourced}; env'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in merged.stdout.splitlines():
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            os.environ[key] = value
+
+        venv_prefix = ''
+        virtual_env = os.environ.get('VIRTUAL_ENV')
+        if virtual_env:
+            venv_prefix = str(Path(virtual_env) / 'bin')
+        extras = []
+        for extra in ('/usr/local/sbin', '/usr/local/bin'):
+            parts = os.environ.get('PATH', '').split(':')
+            if extra not in parts:
+                extras.append(extra)
+        if extras:
+            os.environ['PATH'] = os.environ.get('PATH', '') + ':' + ':'.join(extras)
+        if venv_prefix:
+            current = os.environ.get('PATH', '')
+            if not current.startswith(venv_prefix + ':'):
+                os.environ['PATH'] = f'{venv_prefix}:{current}'
+        print('setup: sourced CANN env from set_env.sh')
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing when
+        ``NPU_READY`` is unset.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Run the full pre_process -> parse -> execute -> post_process flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- 把 `cosdt-ci-test/workflows` 里的 onnxruntime 昇腾入门文档迁到本仓：用户文档、测试子类、薄触发器、首页卡片在同一个 PR。
- 文档按当前正式 GitHub Release 源码编译 `onnxruntime-cann` 再跑最小加法推理，不钉死 PyPI 轮子；否则绿灯对不上 `microsoft/onnxruntime` 的最新 tag。上次因此关掉过 #153。
- 面向香港 A2 runner：直连官方 GitHub、不传 `container_options` / `--volume`，跨 run 复用只放隐藏 `#test-setup` 的 `/root/.cache/huggingface/onnxruntime/`。推理块预期含 `CANNExecutionProvider`，并关掉 CPU 回退。

## Test plan
- [x] 本机 `actionlint`、`py_compile`、解析块数 15 / 预期 8（防空跑）
- [x] 可见正文泄漏检查：无 `/root/.cache`、`cosdt-ci-test`、代理、ModelScope、`:::{note}`
- [x] coder 上按文档字面：克隆并编译 `v1.29.1` 约 21 分钟，安装与造模型通过，`get_available_providers()` 含 `CANNExecutionProvider`
- [ ] coder 缺 `/usr/local/Ascend/driver`，`aclInit` 失败，推理未在该环境跑通；合入后在本仓 A2 runner 上 `workflow_dispatch` 再验冷/热缓存
- [ ] 热缓存：隐藏 restore 命中后，可见编译块应跳过；把缓存改成脏数据后必须删掉再编