### PR TITLE
[feature]支持modelscope的quick start文档测试看护

### DIFF
--- a/.github/workflows/modelscope-quick-start.yml
+++ b/.github/workflows/modelscope-quick-start.yml
@@ -1,0 +1,92 @@
+# ModelScope quick start guard - project thin trigger.
+#
+# Calls the common engine .github/workflows/quick-start-template.yml;
+# this file only declares what varies per project: schedule,
+# concurrency, runner, container image, upstream repo, monitored doc
+# and the test entry command. The guard loop, cache I/O, state relay
+# and publishing all live in the engine. See the engine's
+# `workflow_call.inputs` block for the full input contract.
+#
+# Engine-fixed behaviours this trigger relies on (declared in the
+# engine, NOT here):
+#   * cache key prefix: monitor-state-modelscope-  (from inputs.project)
+#   * artifact name:    modelscope-quick-start-<run_id>
+#   * result.json is written by the engine and validated against
+#     schemas/result.schema.json before upload.
+#
+# ModelScope note: the doc exercises the hub client itself - source
+# install at the latest release tag + `modelscope download` +
+# AutoModelForCausalLM text generation on NPU (modelscope's
+# verify_device whitelist rejects device='npu', so pipeline() is not
+# usable; see the doc's 使用样例 note).
+#
+# Model downloads land in /root/.cache/modelscope: no explicit bind
+# mount is needed because NFS already mounts /root/.cache (same setup
+# as the peft / comfyui triggers).
+
+name: modelscope-quick-start
+
+concurrency:
+  # format() is load-bearing: a '||' between 'manual-' and
+  # github.run_id would short-circuit on the truthy literal and
+  # every dispatch would share one 'manual-' group.
+  group: ${{ github.event_name == 'schedule' && 'modelscope-quick-start-schedule' || format('manual-{0}', github.run_id) }}
+  # cancel-in-progress: false because (1) a schedule run cancelled
+  # mid-way loses its outcome writeback - the outcome is what makes
+  # the retry mechanism work, and the 'if: always()' guard isn't
+  # enough when the container is being torn down; (2) dispatch / PR
+  # runs already live in unique groups so there's nothing to cancel.
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Same 12 h cadence as the comfyui trigger, minute offset (55 vs 45)
+    # so the two jobs don't contend for the single NPU runner slot.
+    - cron: '55 */12 * * *'
+  workflow_dispatch:
+  # PR trigger: docs/tests changes get a guard run. paths filter avoids burning
+  # the self-hosted NPU runner on unrelated PRs. `pull_request` (not
+  # `pull_request_target`): contents: read is enough, no write-token risk.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sources/modelscope/**'
+      - 'tests/modelscope/**'
+
+permissions:
+  contents: read
+
+jobs:
+  modelscope-quick-start:
+    uses: ./.github/workflows/quick-start-template.yml
+    with:
+      # Namespaces cache keys (monitor-state-modelscope-*), artifacts
+      # (modelscope-quick-start-<run_id>) and the test working dir
+      # (tests/modelscope).
+      project: modelscope
+      # Self-hosted NPU runner for the test job only; the engine pins
+      # the cache I/O jobs (restore-cache / publish-and-persist) to
+      # GitHub-hosted ubuntu-latest.
+      test_runner: '["linux-aarch64-a2-1"]'
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+      # 2 h budget: cold run reuses the image torch stack + source
+      # installs modelscope at the latest release tag (uv pip install -e
+      # '.[framework]', whose aarch64 resolver is steered off CUDA wheels
+      # by the CUDA exclusion list) + pulls Qwen2.5-0.5B-Instruct (~1 GB,
+      # warm after the first run via the NFS-mounted /root/.cache) + a
+      # single-card text-generation smoke on a 910B4. Covers several
+      # retries on dependency flakes.
+      timeout_minutes: 120
+      upstream_repo: modelscope/modelscope
+      # Doc URL points to the upstream Ascend/docs repo. {0} is filled by the
+      # engine: PR head SHA on PR runs, 'main' otherwise. Same-repo PRs (head
+      # SHA exists on Ascend/docs) test the PR-version of the doc; fork PRs
+      # (head SHA on a fork) 404 on doc fetch - accepted, since the content
+      # lands on Ascend/docs post-merge.
+      doc_url: 'https://raw.githubusercontent.com/Ascend/docs/{0}/sources/modelscope/quick_start.md'
+      doc_path: https://github.com/Ascend/docs/blob/main/sources/modelscope/quick_start.md
+      # cwd is the repo root inside the checkout; env contract
+      # (MONITORED_DOC_URL / UPSTREAM_REF / NPU_READY) is injected by the
+      # engine. All project env prep and installs live in the test
+      # subclass's prepare_environment hook.
+      test_command: python -m unittest tests.modelscope.test_quick_start_ascend -v 2>&1

--- a/index.rst
+++ b/index.rst
@@ -455,4 +455,5 @@
    sources/timm/index.rst
    sources/wenet/index.rst
    sources/whisper_cpp/index.rst
+   sources/modelscope/index.md
 

--- a/index.rst
+++ b/index.rst
@@ -379,6 +379,12 @@
          <div class="card-footer"><a href="https://github.com/ggerganov/whisper.cpp">官方链接</a><span class="split">|</span><a href="sources/whisper_cpp/install.html">安装指南</a><span class="split">|</span><a href="sources/whisper_cpp/quick_start.html">快速上手</a></div>
       </div>
 
+      <!-- ModelScope -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/huggingface.png')"></div><h3 class="card-title">ModelScope</h3></div>
+         <p class="card-desc">「模型即服务」(MaaS) 开放平台，汇集 AI 社区最先进的机器学习模型。</p>
+         <div class="card-footer"><a href="https://github.com/modelscope/modelscope">官方链接</a><span class="split">|</span><a href="sources/modelscope/quick_start.html">快速上手</a></div>
+      </div>
    </div>
 
 .. -----------------------------------------

--- a/sources/modelscope/index.md
+++ b/sources/modelscope/index.md
@@ -1,0 +1,6 @@
+# ModelScope
+
+ModelScope 通用文档由上游官方维护。本页收录 Ascend NPU 适配的快速上手。
+
+```{include} quick_start.md
+```

--- a/sources/modelscope/quick_start.md
+++ b/sources/modelscope/quick_start.md
@@ -156,7 +156,7 @@ transformers xxx
 **NPU 设备放哪**：modelscope 的 `pipeline(..., device=...)` 目前只接受 `cpu` / `cuda` / `gpu`（`modelscope/utils/device.py` 的 `verify_device` 会拒绝 `npu`），所以本文档走 `AutoModelForCausalLM` 加载后显式 `.to('npu:0')` —— 模型权重下载由 modelscope 的 `from_pretrained` 补丁完成（`snapshot_download`），设备放置由 torch_npu 接管。
 ```
 
-下载模型到 ModelScope Hub 缓存（大陆网络更稳；CI 上 `/root/.cache` 为持久化挂载，`~/.cache/modelscope` 落在其中，重复运行命中缓存）：
+下载模型到 ModelScope Hub 缓存：
 
 ```shell #test-setup
 modelscope download --model Qwen/Qwen2.5-0.5B-Instruct
@@ -216,5 +216,5 @@ generated: xxx
 
 ```{admonition} Note
 :class: note
-`model device: npu:0` 说明模型权重确实落在昇腾设备上，不是 CPU 兜底。generated 是模型生成内容，随采样变化，这里只校验「生成成功且非空」。
+`model device: npu:0` 说明模型权重确实落在昇腾设备上，不是 CPU 兜底。
 ```

--- a/sources/modelscope/quick_start.md
+++ b/sources/modelscope/quick_start.md
@@ -1,0 +1,220 @@
+# Quick Start (Ascend NPU)
+
+在单卡昇腾 NPU 上跑通 [ModelScope](https://modelscope.cn) 的最小链路：从源码安装 modelscope，通过 ModelScope Hub 下载 Qwen2.5-0.5B-Instruct，并在 NPU 上做一次文本生成推理。
+
+## 前置条件
+
+### 硬件
+
+Atlas 900 A2 / A3 训练系列产品（Ascend 910B4 / 910B 等），并按需完成物理机或容器内的设备挂载。
+
+### 基础软件
+
+在跑本文档**之前**，你的机器上需要已经装好并可用：
+
+- 可用的 Python 环境
+- 可用的 CANN（参考[快速安装昇腾环境](https://ascend.github.io/docs/sources/ascend/quick_install.html)）
+- 与上面 CANN 匹配的 `torch` + `torch_npu`，且 `torch` 能正常 `import` 并 `torch.npu.is_available() == True`（参考 [Ascend PyTorch 安装文档](https://gitcode.com/Ascend/pytorch)，按 torch ↔ torch_npu ↔ CANN 三方兼容矩阵选择版本）
+
+### 本文档示例使用的版本
+
+**配套机器**：
+
+- **机器类型**：Atlas 900 A2 PODc（Ascend 910B4，64 GB × 1）
+- **操作系统**：Ubuntu 22.04
+
+**配套镜像**：
+
+swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:9.1.0-910b-ubuntu22.04-py3.12
+
+**软件版本**：
+
+| 组件 | 版本 |
+| --- | --- |
+| Python | 3.12 |
+| CANN | 9.1.0 |
+| torch | 2.9.0+cpu |
+| torch_npu | 2.9.0.post2 |
+| transformers | `<5.0`（NPU 测试优先走 modelscope 导入，失败时 fallback 到 transformers 直接导入） |
+| modelscope | 最新 release 的源码 |
+| 模型 | [Qwen/Qwen2.5-0.5B-Instruct](https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct) |
+
+## 前置安装
+
+确认能看到 NPU 设备：
+
+```shell
+npu-smi info
+```
+
+输出类似：
+
+```
++------------------------------------------------------------------------------------------------+
+| npu-smi 25.5.2                   Version: 25.5.2                                               |
++---------------------------+---------------+----------------------------------------------------+
+| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip                      | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
++===========================+===============+====================================================+
+| 5     910B4               | OK            | 89.9        39                0    / 0             |
+| 0                         | 0000:41:00.0  | 0           0    / 0          2922 / 32768         |
++===========================+===============+====================================================+
+```
+
+```{admonition} Note
+:class: note
+如果 `npu-smi` 不存在，请回到 [Ascend 官方快速安装指南](https://ascend.github.io/docs/sources/ascend/quick_install.html) 补装驱动。
+```
+
+检查 Python 版本：
+
+```shell #test id="check-py"
+python --version
+```
+
+输出结果如下：
+
+```shell #test-result id="check-py" fuzzy='xxx'
+Python 3.12.xxx
+```
+
+检查 torch / torch_npu 是否装好且 NPU 设备可用：
+
+```shell #test id="check-torch"
+python -c "import torch, torch_npu; print('torch=', torch.__version__); print('torch_npu=', torch_npu.__version__); print('is_available:', torch.npu.is_available()); print('count:', torch.npu.device_count())"
+```
+
+输出结果如下：
+
+```shell #test-result id="check-torch"
+torch= 2.9.0+cpu
+torch_npu= 2.9.0.post2
+is_available: True
+count: 1
+```
+
+```{admonition} Note
+:class: note
+如果 `import torch_npu` 失败，回到 [Ascend PyTorch 安装文档](https://gitcode.com/Ascend/pytorch) 检查 torch / torch_npu / CANN 三方兼容矩阵。
+```
+
+## 安装 modelscope
+
+### 使用 pip 进行安装（二进制，用户自选）
+
+```shell
+uv pip install modelscope
+python -c "import modelscope; print('modelscope', modelscope.__version__)"
+```
+
+### 从源码安装
+
+<!--
+```shell #test-setup store="upstream_ref"
+echo "${UPSTREAM_REF}"
+```
+-->
+
+克隆上游仓库并 checkout 到流水线注入的最新 release tag，安装并且验证。`.[framework]` extra 会连带装上 `transformers` / `datasets` 等做 LLM 推理需要的依赖（modelscope 基础安装 `requirements/hub.txt` 不含 torch / transformers）：
+
+```shell #test id="modelscope-install-source" load="upstream_ref>>ref"
+git clone --depth 1 --branch <ref> https://github.com/modelscope/modelscope.git
+cd modelscope
+uv pip install -e '.[framework]'
+uv pip install 'transformers<5.0'
+python -c "import modelscope; print('modelscope importable')"
+```
+\<ref> 为安装的最新的 release 分支
+
+输出结果类似如下：
+
+```shell #test-result id="modelscope-install-source" fuzzy='xxx'
+modelscope importable
+```
+
+- xxx 表示最新的版本号
+
+验证 modelscope 和 transformers 均可导入：
+
+```shell #test id="ms-verify-import"
+python -c "import modelscope; print('modelscope importable'); import transformers; print('transformers', transformers.__version__)"
+```
+
+输出类似：
+
+```shell #test-result id="ms-verify-import" fuzzy='xxx'
+modelscope importable
+transformers xxx
+```
+
+## 使用样例
+
+在单卡昇腾 NPU 上用 modelscope 下载 Qwen2.5-0.5B-Instruct 并做一次文本生成。
+
+```{admonition} Note
+:class: note
+**NPU 设备放哪**：modelscope 的 `pipeline(..., device=...)` 目前只接受 `cpu` / `cuda` / `gpu`（`modelscope/utils/device.py` 的 `verify_device` 会拒绝 `npu`），所以本文档走 `AutoModelForCausalLM` 加载后显式 `.to('npu:0')` —— 模型权重下载由 modelscope 的 `from_pretrained` 补丁完成（`snapshot_download`），设备放置由 torch_npu 接管。
+```
+
+下载模型到 ModelScope Hub 缓存（大陆网络更稳；CI 上 `/root/.cache` 为持久化挂载，`~/.cache/modelscope` 落在其中，重复运行命中缓存）：
+
+```shell #test-setup
+modelscope download --model Qwen/Qwen2.5-0.5B-Instruct
+```
+
+在 NPU 上做文本生成推理：
+
+```shell #test id="ms-npu-infer"
+python - <<'PY'
+import sys
+import torch
+
+try:
+    from modelscope import AutoModelForCausalLM, AutoTokenizer
+except Exception as exc:
+    print(
+        f'diag: modelscope AutoModel import failed: '
+        f'{type(exc).__name__}: {exc}',
+        file=sys.stderr,
+    )
+    from modelscope.hub.snapshot_download import snapshot_download
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    model_id = snapshot_download('Qwen/Qwen2.5-0.5B-Instruct')
+else:
+    model_id = 'Qwen/Qwen2.5-0.5B-Instruct'
+
+import torch_npu
+
+model = AutoModelForCausalLM.from_pretrained(
+    model_id, trust_remote_code=True).to('npu:0')
+tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+print('model device:', next(model.parameters()).device)
+
+messages = [
+    {'role': 'system', 'content': 'You are a helpful assistant.'},
+    {'role': 'user', 'content': '用一句话介绍 ModelScope。'},
+]
+text = tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True)
+model_inputs = tokenizer([text], return_tensors='pt').to('npu:0')
+generated_ids = model.generate(**model_inputs, max_new_tokens=64)
+generated_ids = [
+    out[len(inp):] for inp, out in zip(model_inputs.input_ids, generated_ids)
+]
+response = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
+print('generated:', response)
+PY
+```
+
+输出结果类似如下：
+
+```shell #test-result id="ms-npu-infer" fuzzy='xxx'
+model device: npu:0
+generated: xxx
+```
+
+```{admonition} Note
+:class: note
+`model device: npu:0` 说明模型权重确实落在昇腾设备上，不是 CPU 兜底。generated 是模型生成内容，随采样变化，这里只校验「生成成功且非空」。
+```

--- a/tests/modelscope/__init__.py
+++ b/tests/modelscope/__init__.py
@@ -1,0 +1,29 @@
+"""Tests package marker.
+
+Single responsibility: inject the repo's ``tests/`` into ``sys.path``
+so that ``from doc_test.base import ...`` can resolve.
+
+Framework deps (mistune) are installed by the common quick-start workflow
+template, not at import time here.
+
+Why it lives here:
+* unittest treats ``tests/`` as a package; the parent package marker
+  executes before any submodule import.
+* It runs before ``tests/test_*.py`` import, which is the earliest
+  opportunity to inject ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# sys.path bootstrap: make ``doc_test.*`` resolvable.
+# Layout: tests/modelscope/__init__.py -> parents[0]=tests/modelscope,
+# parents[1]=tests, parents[2]=repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / 'tests'
+for _p in (_TESTS_ROOT, _REPO_ROOT):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)

--- a/tests/modelscope/test_quick_start_ascend.py
+++ b/tests/modelscope/test_quick_start_ascend.py
@@ -1,0 +1,263 @@
+"""Quick-start test: doc under test is ``sources/modelscope/quick_start.md``.
+
+End-to-end case built on top of the ``MarkdownDocTestBase`` contract:
+env check + modelscope source install at the latest release tag +
+Qwen2.5-0.5B-Instruct download via the modelscope CLI + a single-card
+text-generation smoke on NPU. The inference block goes through
+``AutoModelForCausalLM`` + ``.to('npu:0')`` (with a transformers
+fallback) because modelscope's own ``verify_device`` whitelist rejects
+``device='npu'`` — that limitation is documented in the doc itself.
+
+Run: ``python -m unittest tests.modelscope.test_quick_start_ascend -v 2>&1``
+
+Environment variables (injected by GitHub workflow
+``modelscope-quick-start.yml``):
+    ``MONITORED_DOC_URL``         doc to fetch and execute
+    ``UPSTREAM_REF``              release tag substituted into the doc's <ref>
+    ``NPU_READY=true``            Required, otherwise the class is skipped.
+                                  End-to-end tests only run on the NPU runner:
+                                  local dev machines / normal ubuntu runners
+                                  have no ``/dev/davinci*`` device, and the
+                                  hard run would fail on ``import torch_npu``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+
+from doc_test.base import MarkdownDocTestBase
+from doc_test.model_cache import (
+    diagnose_mount_environment,
+    ensure_safetensors,
+    purge_modelscope_corrupt,
+    report_modelscope_state,
+    resolve_modelscope_cache,
+)
+
+
+def _is_truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() == 'true'
+
+
+def _e2e_enabled() -> bool:
+    return _is_truthy(os.environ.get('NPU_READY'))
+
+
+class TestQuickStartAscend(MarkdownDocTestBase, unittest.TestCase):
+    # 60 min per command: long enough for the modelscope source install
+    # (`git clone` + `uv pip install -e '.[framework]'`, whose aarch64
+    # resolver is steered off CUDA wheels by the CUDA exclusion list)
+    # plus the first-run Qwen2.5-0.5B-Instruct (~1 GB) download, which
+    # needs longer than the 30 min default of the smaller projects.
+    DEFAULT_COMMAND_TIMEOUT = 3600
+
+    USER_AGENT = 'cosdt-ci-test/quick-start'  # monitored source lives under this org
+
+    # Extend the base ERROR_MARKERS with CANN's typo + sentinel so a CANN
+    # failure surfaces a full stderr dump (head/tail by default would hide
+    # the line that names the failure).
+    ERROR_MARKERS = (
+        *MarkdownDocTestBase.ERROR_MARKERS,  # generic [ERROR] + Traceback
+        'applicaiton exception',  # typo in CANN's Python driver (sic)
+        'ERR99999',  # CANN sentinel for unrecoverable runtime failure
+    )
+
+    # Process-level CUDA exclusion list. Same rationale as the other
+    # projects' tests: write to /tmp and export, so subprocesses
+    # (subprocess.run inherits parent env by default) see it. modelscope's
+    # dep tree itself doesn't pull CUDA, but bare ``torch`` /
+    # ``torchvision`` wheels from the default PyPI index depend on
+    # nvidia-* packages; the constraints keep any accidental re-resolution
+    # of the torch stack from dragging them in and breaking the
+    # torch_npu pairing.
+    _CUDA_CONSTRAINTS = (
+        'cuda-toolkit<0',
+        'cuda-python<0',
+        'cuda-bindings<0',
+        'cuda-core<0',
+        'cuda-pathfinder<0',
+        'flashinfer-python<0',
+        'nvidia-cublas<0',
+        'nvidia-cuda-runtime<0',
+        'nvidia-cuda-nvrtc<0',
+        'nvidia-cuda-cupti<0',
+        'nvidia-cudnn<0',
+        'nvidia-cudnn-frontend<0',
+        'nvidia-cufft<0',
+        'nvidia-curand<0',
+        'nvidia-cusolver<0',
+        'nvidia-cusparse<0',
+        'nvidia-cutlass-dsl<0',
+        'nvidia-cutlass-dsl-libs-base<0',
+        'nvidia-cutlass-dsl-libs-core<0',
+        'nvidia-cutlass-dsl-libs-cu12<0',
+        'nvidia-ml-py<0',
+        'nvidia-nccl<0',
+        'nvidia-nvjitlink<0',
+        'nvidia-nvtx<0',
+        'nvidia-cublas-cu12<0',
+        'nvidia-cuda-nvdisasm<0',
+        'nvidia-cuda-runtime-cu12<0',
+        'nvidia-cuda-nvrtc-cu12<0',
+        'nvidia-cuda-cupti-cu12<0',
+        'nvidia-cudnn-cu12<0',
+        'nvidia-cufft-cu12<0',
+        'nvidia-curand-cu12<0',
+        'nvidia-cusolver-cu12<0',
+        'nvidia-cusparse-cu12<0',
+        'nvidia-cusparselt-cu12<0',
+        'nvidia-nccl-cu12<0',
+        'nvidia-nvjitlink-cu12<0',
+        'nvidia-nvtx-cu12<0',
+    )
+    _CONSTRAINTS_FILE = '/tmp/modelscope_npu_constraints.txt'
+
+    # Cluster-internal nginx PyPI cache + Huawei Cloud ascend dual-source.
+    _CLUSTER_INDEX = 'http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple'
+    _ASCEND_EXTRA = 'https://repo.huaweicloud.com/ascend/repos/pypi'
+
+    # ModelScope hub repo carrying Qwen2.5-0.5B-Instruct; downloads go
+    # through modelscope's own CLI / from_pretrained patch (the project
+    # under test IS the ModelScope hub client, so no HF fallback here).
+    _MODEL_ID = 'Qwen/Qwen2.5-0.5B-Instruct'
+
+    # CANN toolkit: source once to get ASCEND_HOME / LD_LIBRARY_PATH etc.
+    # Path is hard-coded, tied to the container image pinned by the
+    # ``image:`` input of ``modelscope-quick-start.yml``.
+    _CANN_SET_ENV = '/usr/local/Ascend/ascend-toolkit/set_env.sh'
+
+    @classmethod
+    def prepare_environment(cls) -> None:
+        """Source CANN env + write CUDA exclusion list + install uv +
+        torch stack probe + safetensors + modelscope cache validation.
+
+        The doc's ``## 安装 modelscope`` block is the single source of
+        truth for which modelscope deps get installed (source install);
+        this class only handles ``torch`` / ``torch_npu`` here (via the
+        cluster cache + Huawei ascend dual-source). Everything else
+        installs in document order via the ``#test`` machinery.
+        """
+        # 0) CANN env: source set_env.sh and merge the env stream into
+        # os.environ
+        if os.path.isfile(cls._CANN_SET_ENV):
+            merged = subprocess.run(
+                ['bash', '-c', f'source {cls._CANN_SET_ENV} >/dev/null 2>&1; env'],
+                capture_output=True, text=True, check=True,
+            )
+            for line in merged.stdout.splitlines():
+                if '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                # Don't overwrite envs explicitly injected by the
+                # workflow (jobs.env / steps.env); only fill in CANN
+                # keys that are missing, to avoid conflicts.
+                os.environ.setdefault(key, value)
+            print('setup: sourced CANN env from set_env.sh')
+        else:
+            print(
+                f'setup: skipping CANN env source ({cls._CANN_SET_ENV} not present)'
+            )
+
+        # 1) CUDA exclusion list + process-level env
+        with open(cls._CONSTRAINTS_FILE, 'w', encoding='utf-8') as fh:
+            fh.write('\n'.join(cls._CUDA_CONSTRAINTS) + '\n')
+        os.environ['PIP_CONSTRAINT'] = cls._CONSTRAINTS_FILE
+        os.environ['UV_CONSTRAINT'] = cls._CONSTRAINTS_FILE
+
+        # 2) uv: the doc's install blocks call ``uv pip`` (source install
+        # of modelscope + transformers pin), so uv must exist before the
+        # doc executes. Inherit ``PIP_INDEX_URL`` + ``PIP_TRUSTED_HOST``
+        # from the yml job-level env (cluster cache path + trusted-host).
+        subprocess.run(
+            ['python', '-m', 'pip', 'install', 'uv'],
+            check=True,
+        )
+
+        # 3) torch stack probe: when version matches the image's
+        # pre-installed wheels, reuse them to avoid the cluster cache
+        # triggering ``+cpu`` resolution.
+        _PROBE_SCRIPT = (
+            'import torch, torch_npu\n'
+            "raise SystemExit(0 if "
+            "torch.__version__.startswith('2.9.0') "
+            "and torch_npu.__version__.startswith('2.9.0') "
+            "else 1)"
+        )
+        probe = subprocess.run(
+            ['python', '-c', _PROBE_SCRIPT],
+            capture_output=True,
+            check=False,  # probe's success/failure is the branch signal — don't raise
+        )
+        if probe.returncode == 0:
+            _VERSIONS_SCRIPT = (
+                'import torch, torch_npu; '
+                'print(torch.__version__, torch_npu.__version__)'
+            )
+            versions = subprocess.run(
+                ['python', '-c', _VERSIONS_SCRIPT],
+                capture_output=True, text=True, check=True,
+            )
+            print(f'setup: reusing image torch stack ({versions.stdout.strip()})')
+        else:
+            print('setup: installing torch==2.9.0 torch_npu==2.9.0.post2')
+            subprocess.run(
+                [
+                    'python', '-m', 'pip', 'install',
+                    '--index-url', cls._CLUSTER_INDEX,
+                    '--extra-index-url', cls._ASCEND_EXTRA,
+                    'torch==2.9.0', 'torch_npu==2.9.0.post2',
+                ],
+                check=True,
+            )
+
+        # 4) Single-card determinism: the doc's check-torch block asserts
+        # ``count: 1``; pinning the visible device keeps that assertion
+        # true even if the cluster assigns a multi-card container.
+        os.environ.setdefault('ASCEND_RT_VISIBLE_DEVICES', '0')
+
+        # 5) safetensors: native loader used by the cache validation
+        # step below. Pulled in transitively by torch on most images;
+        # install defensively in case the CANN base ships without it.
+        ensure_safetensors()
+
+        # 6) ModelScope cache validation: the doc downloads
+        # Qwen/Qwen2.5-0.5B-Instruct (~1 GB) via the modelscope CLI on
+        # the first run. A persistent host-side cache can hold truncated
+        # safetensors from interrupted runs; report the current state,
+        # then walk every shard under each model dir and purge it on
+        # failure so the next access re-downloads cleanly. The
+        # throughput / mount probes inside diagnose_mount_environment
+        # target the modelscope cache root by default.
+        diagnose_mount_environment()
+
+        report_modelscope_state(cls._MODEL_ID)
+        purge_modelscope_corrupt(resolve_modelscope_cache())
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run env setup once per class. ``@unittest.skipIf`` only skips
+        the test *method* — ``setUpClass`` itself always runs, so the
+        ``if _e2e_enabled()`` guard keeps heavy setup from firing on
+        non-NPU runners.
+        """
+        if _e2e_enabled():
+            cls.prepare_environment()
+
+    @unittest.skipIf(
+        not _e2e_enabled(),
+        'end-to-end requires NPU runner; set NPU_READY=true',
+    )
+    def test_runs_doc(self) -> None:
+        """Template-method entry point. The base class ``run_template()``
+        runs the full ``pre_process`` -> ``parse`` -> ``execute`` ->
+        ``post_process`` flow."""
+
+        self.run_template()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- 将 workflows 仓库中 ModelScope 的 quick start 看护迁移到 docs 仓库，模式与 #142 (peft) / ComfyUI 迁移保持一致
- 新增 `sources/modelscope/`（index.md + quick_start.md）、`tests/modelscope/`（`__init__.py` + `test_quick_start_ascend.py`）、`.github/workflows/modelscope-quick-start.yml`（薄触发器，调用 quick-start-template 引擎：12h cron + dispatch + PR path 过滤）
- 测试链路：环境检查 → modelscope 源码安装（最新 release tag + `.[framework]` extra）→ `modelscope download` 拉取 Qwen2.5-0.5B-Instruct → 单卡 NPU 文本生成推理（`AutoModelForCausalLM` + `.to('npu:0')`；modelscope 的 `verify_device` 白名单不接受 `npu`，已在文档 Note 中说明）
- 测试类沿用 ComfyUI 迁移后的约定：`DEFAULT_COMMAND_TIMEOUT=3600`、CANN env source、CUDA 排除清单、torch 栈探测复用镜像版本、modelscope 缓存校验（`diagnose_mount_environment` / `report_modelscope_state` / `purge_modelscope_corrupt`）
- 索引注册：index.rst 新增 ModelScope 卡片（Whisper.cpp 卡片之后）与 toctree 条目；描述采用 ModelScope 官方 README 的「模型即服务 (MaaS)」表述；图标暂复用 huggingface.png（无 ModelScope 专属图标）
- 无模型缓存 bind mount：NFS 已挂载 /root/.cache（`~/.cache/modelscope` 落在其中），与 peft / ComfyUI 触发器一致

## Test plan
- [ ] PR 触发 `modelscope-quick-start` 守护流水线（paths 过滤 sources/modelscope/**、tests/modelscope/**），NPU runner 上端到端跑通
- [ ] 合入后 `workflow_dispatch` 手动跑一次，确认 monitor-state-modelscope-* 缓存与 result.json 上传正常
- [ ] 确认 docs 站点构建中 sources/modelscope 页面渲染正常（myst include + admonition）
