### PR TITLE
[docs] 新增 cache-dit：快速上手链到官方 NPU 启动文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository is a collection of documentation for Ascend supported open sourc
 
 ## Documentation from Official Project Sites
 
-Some communities already maintain Ascend/NPU documentation on their own sites. Those projects are linked from the homepage cards in `index.rst` instead of being built locally. Examples: verl, LLaMA-Factory, ms-swift, VeOmni, vllm-ascend, Triton-Ascend, DeepSpeed, ONNX Runtime, SGLang, LMDeploy, ROLL, and Twinkle.
+Some communities already maintain Ascend/NPU documentation on their own sites. Those projects are linked from the homepage cards in `index.rst` instead of being built locally. Examples: verl, LLaMA-Factory, ms-swift, VeOmni, vllm-ascend, Triton-Ascend, DeepSpeed, ONNX Runtime, SGLang, LMDeploy, ROLL, Twinkle, and cache-dit.
 
 To add such a project, create a lightweight `sources/<project>/index.rst` with links to the official docs, and add it to the hidden toctree in `index.rst` so it appears in the sidebar.
 

--- a/index.rst
+++ b/index.rst
@@ -243,6 +243,13 @@
    <h2 class="scene-header">🚀 高性能推理与服务</h2>
    <div class="grid-container">
 
+      <!-- cache-dit：官方文档已含昇腾说明，外链跳转，不再本地编译 -->
+      <div class="project-card">
+         <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/huggingface.png')"></div><h3 class="card-title">cache-dit</h3></div>
+         <p class="card-desc">A PyTorch-native Inference Engine with Cache, Parallelism, Quantization and CPU Offload for DiTs.</p>
+         <div class="card-footer"><a href="https://github.com/vipshop/cache-dit">官方链接</a><span class="split">|</span><a href="https://cache-dit.readthedocs.io/en/latest/">文档中心</a><span class="split">|</span><a href="https://github.com/vipshop/cache-dit/blob/main/docs/user_guide/ASCEND_NPU.md">昇腾教程</a></div>
+      </div>
+
       <!-- llama.cpp -->
       <div class="project-card">
          <div class="card-top"><div class="card-icon" style="background-image: url('_static/images/llama_cpp.png')"></div><h3 class="card-title">llama.cpp</h3></div>
@@ -425,6 +432,7 @@
    :hidden:
    :caption: 🚀 推理与服务
 
+   sources/cache-dit/index.rst
    sources/llama_cpp/index.rst
    sources/lm_deploy/index.rst
    sources/onnxruntime/index.rst

--- a/sources/cache-dit/index.rst
+++ b/sources/cache-dit/index.rst
@@ -1,0 +1,8 @@
+cache-dit
+=========
+
+昇腾相关文档由 cache-dit 官方维护，请访问官方文档站：
+
+- GitHub：`cache-dit <https://github.com/vipshop/cache-dit>`_
+- 文档中心：`Cache-DiT Docs <https://cache-dit.readthedocs.io/en/latest/>`_
+- 昇腾教程：`Ascend NPU Support <https://github.com/vipshop/cache-dit/blob/main/docs/user_guide/ASCEND_NPU.md>`_


### PR DESCRIPTION
## Summary
- 新增 cache-dit 项目入口，沿用 sglang/lmdeploy 外链模式：官方文档站已含 Ascend NPU 说明，不做本地编译，卡片直接跳转官方页面
- 新增轻量 stub 页 `sources/cache-dit/index.rst`（GitHub / 文档中心 / 官方 Ascend NPU 指南三条外链）
- `index.rst` 在「🚀 高性能推理与服务」区新增 cache-dit 卡片，并在「🚀 推理与服务」toctree 中注册（仅新增，未改动既有内容）
- `README.md` 的 "Documentation from Official Project Sites" 项目示例列表追加 cache-dit

## Links
- 官方仓库：https://github.com/vipshop/cache-dit
- 官方文档站：https://cache-dit.readthedocs.io/en/latest/
- Ascend NPU 官方文档：https://github.com/vipshop/cache-dit/blob/main/docs/user_guide/ASCEND_NPU.md

## Test plan
- [ ] gh-pages 构建通过（新增 toctree 条目 `sources/cache-dit/index.rst` 可被 Sphinx 正常收录）
- [ ] 首页卡片三条外链可正常跳转（GitHub / readthedocs / ASCEND_NPU.md）
